### PR TITLE
bugfix for setting digital channels > 8

### DIFF
--- a/src/u12.py
+++ b/src/u12.py
@@ -2081,14 +2081,14 @@ class U12(object):
             
             if writeD:
                 if channel > 7:
-                    channel = channel-7
+                    channel = channel-8
                     direction = BitField(rawByte = int(oldstate['D15toD8Directions']))
                     direction[7-channel] = 0
                     
                     states = BitField(rawByte = int(oldstate['D15toD8States']))
                     states[7-channel] = state
                     
-                    self.rawDIO(D15toD8Directions = direction, D15toD8States = state, UpdateDigital = True)
+                    self.rawDIO(D15toD8Directions = direction, D15toD8States = states, UpdateDigital = True)
                     
                 else:
                     direction = BitField(rawByte = int(oldstate['D7toD0Directions']))


### PR DESCRIPTION
There's been a typo and index error preventing

``` python
d = u12.U12()
d.eDigitalOut(channel = 15, state = 1, writeD=1)
```

from work.
