### PR TITLE
Import collections directly instead of through LabJackPython

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -12,7 +12,6 @@ A typical user should start with their device's module, such as u3.py.
 # We use the 'with' keyword to manage the thread-safe device lock. It's built-in on 2.6; 2.5 requires an import.
 from __future__ import with_statement
 
-import collections
 import ctypes
 import os
 import struct

--- a/src/u3.py
+++ b/src/u3.py
@@ -17,7 +17,7 @@ Section Number Mapping:
 
 """
 from LabJackPython import *
-import struct, ConfigParser
+import collections, struct, ConfigParser
 
 FIO0, FIO1, FIO2, FIO3, FIO4, FIO5, FIO6, FIO7, \
 EIO0, EIO1, EIO2, EIO3, EIO4, EIO5, EIO6, EIO7, \

--- a/src/u6.py
+++ b/src/u6.py
@@ -12,7 +12,7 @@ http://labjack.com/support/u6/users-guide/5.2
 """
 from LabJackPython import *
 
-import struct, ConfigParser
+import collections, struct, ConfigParser
 
 def openAllU6():
     """

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -11,7 +11,7 @@ http://labjack.com/support/ue9/users-guide/5.2
 """
 from LabJackPython import *
 
-import struct, socket, select, ConfigParser
+import collections, struct, socket, select, ConfigParser
 from datetime import datetime
 
 def openAllUE9():


### PR DESCRIPTION
`LabJackPython` imports `collections` but does not use it.  However, other modules are using `collections` through `LabJackPython` as a side effect of `from LabJackPython import *`.

Remove `import collections` from `LabJackPython` and add it to the modules that need it.  This makes imports clearer and more consistent (e.g. each module that uses `struct` already imports it directly).  This will also fix unused import warnings when static analysis tools like pyflakes are used on `LabJackPython.py`.
