### PR TITLE
Remove unused variable readBytes from read()

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -287,8 +287,6 @@ class Device(object):
             
         Blocking read until a packet is received.
         """
-        readBytes = 0
-        
         if self.handle is None:
             raise LabJackException("The device handle is None.")
         


### PR DESCRIPTION
The local `readBytes` is assigned to but never used.