### PR TITLE
Remove unused variable marked from listAll()

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -1075,7 +1075,6 @@ def listAll(deviceType, connectionType = 1):
             
         if status.lower().startswith('ok'):
             lines = []
-            marked = None
             for i in range(int(numLines)):
                 l = f.readline().strip()
                 dev = parseline(l)


### PR DESCRIPTION
The local `marked` is assigned to but never used.