### PR TITLE
Move sys imports to the top of the file

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -18,6 +18,7 @@ import Modbus
 import atexit # For auto-closing devices
 import threading # For a thread-safe device lock
 import ctypes
+import sys
 
 LABJACKPYTHON_VERSION = "4-24-2014"
 
@@ -107,7 +108,6 @@ def _loadLibrary():
     """_loadLibrary()
     Returns a ctypes dll pointer to the library.
     """
-    import sys
     global _os_name
 
     _os_name = "nt"
@@ -1090,7 +1090,6 @@ def listAll(deviceType, connectionType = 1):
     
     if deviceType == 12:
         if U12DriverPresent():
-            import sys
             if(sys.platform.startswith("cygwin")):
                 u12Driver = ctypes.cdll.LoadLibrary("ljackuw")
             else:

--- a/src/u12.py
+++ b/src/u12.py
@@ -28,6 +28,7 @@ import atexit
 import math
 from time import time
 import struct
+import sys
 
 _os_name = "" #Set to "nt" or "posix" in _loadLibrary
 
@@ -364,7 +365,6 @@ def _loadLibrary():
     """_loadLibrary()
     Returns a ctypes dll pointer to the library.
     """
-    import sys
     global _os_name
 
     _os_name = "nt"


### PR DESCRIPTION
Replaces multiple inline imports with one at the top of the file, keeping all stdlib imports together. 