### PR TITLE
Remove unused variable rcvDataBuff from openLabjack()

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -1464,7 +1464,6 @@ def openLabJack(deviceType, connectionType, firstFound = True, pAddress = None, 
     
         Note: On Windows, Ue9 over Ethernet, pAddress MUST be the IP address. 
     """
-    rcvDataBuff = []
     handle = None
 
     if connectionType == LJ_ctLJSOCKET:


### PR DESCRIPTION
The local `rcvDataBuff` is assigned to but never used.