### PR TITLE
Use identity comparison when testing for None

### DIFF
--- a/Examples/EI1050/ei1050SampleApp.py
+++ b/Examples/EI1050/ei1050SampleApp.py
@@ -122,7 +122,7 @@ class MainWindow:
         Desc: Gets the latest reading from the readings queue and display it
         """
         # Check for errors
-        if self.thread.exception != None:
+        if self.thread.exception is not None:
             showErrorWindow(self.thread.exception[0], self.thread.exception[1])
 
         else:   
@@ -131,7 +131,7 @@ class MainWindow:
             while not self.targetQueue.empty():
                 latestReading = self.targetQueue.get()
 
-            if latestReading != None:
+            if latestReading is not None:
                 self.tempDisplay.config(text = str(latestReading.getTemperature()) + " deg C")
                 self.humidDisplay.config(text = str(latestReading.getHumidity()) + " %")
                 self.statusDisplay.config(text = str(latestReading.getStatus()))
@@ -155,10 +155,10 @@ Brown(Enable) -- FIO3''')
 
     def close(self):
         try:
-            if self.thread != None:
+            if self.thread is not None:
                 self.thread.stop()
                 self.thread.join()
-            if self.device != None:
+            if self.device is not None:
                 self.device.close()
         except: print "error terminating app"
         finally:

--- a/Examples/LJTickDAC/LJTickDAC.py
+++ b/Examples/LJTickDAC/LJTickDAC.py
@@ -205,7 +205,7 @@ class LJTickDAC(Tk):
         Desc: updates the configuration of the application
         """
         try:
-            if self.ainReadThread != None: self.ainReadThread.stop()
+            if self.ainReadThread is not None: self.ainReadThread.stop()
             self.device.close()
             self.ainPin = ainPin
             self.dacPin = dacPin
@@ -225,8 +225,8 @@ class LJTickDAC(Tk):
         Name: cleanUp()
         Desc: Closes devices, terminates threads, and closes windows
         """
-        if self.ainReadThread != None: self.ainReadThread.stop()
-        if self.device != None: self.device.close()
+        if self.ainReadThread is not None: self.ainReadThread.stop()
+        if self.device is not None: self.device.close()
         self.destroy()
 
     def getCalConstants(self):

--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -427,7 +427,7 @@ class Device(object):
             packFormat = ">" + "B" * numBytes
             response = struct.pack(packFormat, *response)
 
-        if format == None:
+        if format is None:
             format = Modbus.calcFormat(addr, numReg)
 
         value = Modbus.readHoldingRegistersResponse(response, payloadFormat=format)
@@ -1205,7 +1205,7 @@ def deviceCount(devType = None):
         else:
             return len(listAll(devType))
     else:
-        if devType == None:
+        if devType is None:
             numdev = staticLib.LJUSB_GetDevCount(3)
             numdev += staticLib.LJUSB_GetDevCount(9)
             numdev += staticLib.LJUSB_GetDevCount(6)
@@ -1312,7 +1312,7 @@ def _openLabJackUsingExodriver(deviceType, firstFound, pAddress, devNumber):
     openDev = staticLib.LJUSB_OpenDevice
     openDev.restype = ctypes.c_void_p
     
-    if devNumber != None:
+    if devNumber is not None:
         handle = openDev(devNumber, 0, devType)
         if handle <= 0:
             raise NullHandleException()
@@ -1419,7 +1419,7 @@ def _openWirelessBridgeOnWindows(firstFound, pAddress, devNumber):
     openDev = skymoteLib.LJUSB_OpenDevice
     openDev.restype = ctypes.c_void_p
     
-    if devNumber != None:
+    if devNumber is not None:
         handle = openDev(devNumber, 0, devType)
         if handle <= 0:
             raise NullHandleException()

--- a/src/u3.py
+++ b/src/u3.py
@@ -978,8 +978,8 @@ class U3(Device):
         if len(PChannels) != len(NChannels):
             raise LabJackException("Length of PChannels didn't match the length of NChannels")
         
-        if ScanFrequency != None or SampleFrequency != None:
-            if ScanFrequency == None:
+        if (ScanFrequency is not None) or (SampleFrequency is not None):
+            if ScanFrequency is None:
                 ScanFrequency = SampleFrequency
             if ScanFrequency < 1000:
                 if ScanFrequency < 25:
@@ -1458,7 +1458,7 @@ class U3(Device):
         command[7] = SpeedAdjust
         command[8] = SDAPinNum
         command[9] = SCLPinNum
-        if AddressByte != None:
+        if AddressByte is not None:
             command[10] = AddressByte
         else:
             command[10] = Address << 1
@@ -2442,7 +2442,7 @@ class Timer(FeedbackCommand):
         self.mode = Mode
         if timer != 0 and timer != 1:
             raise LabJackException("Timer should be either 0 or 1.")
-        if UpdateReset and Value == None:
+        if UpdateReset and (Value is None):
             raise LabJackException("UpdateReset set but no value.")
             
         

--- a/src/u6.py
+++ b/src/u6.py
@@ -237,7 +237,7 @@ class U6(Device):
         #command[4]  = Checksum16 (LSB)
         #command[5]  = Checksum16 (MSB)
         
-        if LocalID != None:
+        if LocalID is not None:
             command[6] = (1 << 3)
             command[8] = LocalID
             
@@ -295,23 +295,23 @@ class U6(Device):
         #command[4]  = Checksum16 (LSB)
         #command[5]  = Checksum16 (MSB)
         
-        if NumberTimersEnabled != None:
+        if NumberTimersEnabled is not None:
             command[6] = 1
             command[7] = NumberTimersEnabled
         
-        if EnableCounter0 != None:
+        if EnableCounter0 is not None:
             command[6] = 1
             
             if EnableCounter0:
                 command[8] = 1
         
-        if EnableCounter1 != None:
+        if EnableCounter1 is not None:
             command[6] = 1
             
             if EnableCounter1:
                 command[8] |= (1 << 1)
         
-        if TimerCounterPinOffset != None:
+        if TimerCounterPinOffset is not None:
             command[6] = 1
             command[9] = TimerCounterPinOffset
             
@@ -350,11 +350,11 @@ class U6(Device):
         #command[6]  = Reserved
         #command[7]  = Reserved
         
-        if TimerClockBase != None:
+        if TimerClockBase is not None:
             command[8] = (1 << 7)
             command[8] |= TimerClockBase & 7
         
-        if TimerClockDivisor != None:
+        if TimerClockDivisor is not None:
             command[9] = TimerClockDivisor
             
         result = self._writeRead(command, 10, [0xF8, 0x2, 0x0A])
@@ -604,8 +604,8 @@ class U6(Device):
         if len(ChannelNumbers) != len(ChannelOptions):
             raise LabJackException("len(ChannelNumbers) doesn't match len(ChannelOptions)")
         
-        if ScanFrequency != None or SampleFrequency != None:
-            if ScanFrequency == None:
+        if (ScanFrequency is not None) or (SampleFrequency is not None):
+            if ScanFrequency is None:
                 ScanFrequency = SampleFrequency
             if ScanFrequency < 1000:
                 if ScanFrequency < 25:
@@ -886,7 +886,7 @@ class U6(Device):
         if UARTEnable:
             command[7] |= (1 << 6)
         
-        if DesiredBaud != None:
+        if DesiredBaud is not None:
             BaudFactor = (2**16) - 48000000/(2 * DesiredBaud)   
         
         t = struct.pack("<H", BaudFactor)
@@ -992,7 +992,7 @@ class U6(Device):
         command[8] = SDAPinNum
         command[9] = SCLPinNum
         
-        if AddressByte != None:
+        if AddressByte is not None:
             command[10] = AddressByte
         else:
             command[10] = Address << 1
@@ -2130,7 +2130,7 @@ class Timer(FeedbackCommand):
     def __init__(self, timer, UpdateReset = False, Value=0, Mode = None):
         if timer not in range(4):
             raise LabJackException("Timer should be 0-3.")
-        if UpdateReset and Value == None:
+        if UpdateReset and (Value is None):
             raise LabJackException("UpdateReset set but no value.")
         
         self.timer = timer

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -126,44 +126,44 @@ class UE9(Device):
         #command[5] = Checksum16 (MSB)
         #command[6] = Writemask. Set it along the way.
         #command[7] = Reserved
-        if LocalID != None:
+        if LocalID is not None:
             command[6] |= 1
             command[8] = LocalID
         
-        if IPAddress != None:
+        if IPAddress is not None:
             command[6] |= (1 << 2)
             ipbytes = IPAddress.split('.')
             ipbytes = [ int(x) for x in ipbytes ]
             ipbytes.reverse()
             command[10:14] = ipbytes
         
-        if Gateway != None:
+        if Gateway is not None:
             command[6] |= (1 << 3)
             gwbytes = Gateway.split('.')
             gwbytes = [ int(x) for x in gwbytes ]
             gwbytes.reverse()
             command[14:18] = gwbytes
         
-        if Subnet != None:
+        if Subnet is not None:
             command[6] |= (1 << 4)
             snbytes = Subnet.split('.')
             snbytes = [ int(x) for x in snbytes ]
             snbytes.reverse()
             command[18:21] = snbytes
             
-        if PortA != None:
+        if PortA is not None:
             command[6] |= (1 << 5)
             t = struct.pack("<H", PortA)
             command[22] = ord(t[0])
             command[23] = ord(t[1])
         
-        if PortB != None:
+        if PortB is not None:
             command[6] |= (1 << 5)
             t = struct.pack("<H", PortB)
             command[24] = ord(t[0])
             command[25] = ord(t[1])
 
-        if DHCPEnabled != None:
+        if DHCPEnabled is not None:
             command[6] |= (1 << 6)
             if DHCPEnabled:
                 command[26] = 1
@@ -301,7 +301,7 @@ class UE9(Device):
         ips = [IP0, IP1, IP2, IP3, IP4]
         startbyte = 8
         for ip in ips:
-            if ip != None:
+            if ip is not None:
                 ipbytes = ip.split('.')
                 ipbytes = [ int(x) for x in ipbytes ]
                 ipbytes.reverse()
@@ -381,63 +381,63 @@ class UE9(Device):
         #command[5] = Checksum16 (MSB)
         #command[6] = Writemask. Set it along the way.
         
-        if PowerLevel != None:
+        if PowerLevel is not None:
             command[6] |= 1
             command[7] = PowerLevel
         
-        if FIODir != None:
+        if FIODir is not None:
             command[6] |= (1 << 1)
             command[8] = FIODir
         
-        if FIOState != None:
+        if FIOState is not None:
             command[6] |= (1 << 1)
             command[9] = FIOState
         
-        if EIODir != None:
+        if EIODir is not None:
             command[6] |= (1 << 1)
             command[10] = EIODir
         
-        if EIOState != None:
+        if EIOState is not None:
             command[6] |= (1 << 1)
             command[11] = EIOState
         
-        if CIODirection != None:
+        if CIODirection is not None:
             command[6] |= (1 << 1)
             command[12] = ( CIODirection & 0xf) << 4
         
-        if CIOState != None:
+        if CIOState is not None:
             command[6] |= (1 << 1)
             command[12] |= ( CIOState & 0xf )
         
-        if DoNotLoadDigitalIODefaults != None:
+        if DoNotLoadDigitalIODefaults is not None:
             command[6] |= (1 << 1)
             if DoNotLoadDigitalIODefaults:
                 command[13] |= (1 << 7)
         
-        if MIODirection != None:
+        if MIODirection is not None:
             command[6] |= (1 << 1)
             command[13] |= ( MIODirection & 7 ) << 4
         
-        if MIOState != None:
+        if MIOState is not None:
             command[6] |= (1 << 1)
             command[13] |= ( MIOState & 7 )
         
-        if DAC0Enable != None:
+        if DAC0Enable is not None:
             command[6] |= (1 << 2)
             if DAC0Enable:
                 command[15] = (1 << 7)
         
-        if DAC0 != None:
+        if DAC0 is not None:
             command[6] |= (1 << 2)
             command[14] = DAC0 & 0xff
             command[15] |= (DAC0 >> 8 ) & 0xf
         
-        if DAC1Enable != None:
+        if DAC1Enable is not None:
             command[6] |= (1 << 2)
             if DAC1Enable:
                 command[17] = (1 << 7)
         
-        if DAC1 != None:
+        if DAC1 is not None:
             command[6] |= (1 << 2)
             command[16] = DAC1 & 0xff
             command[17] |= (DAC1 >> 8 ) & 0xf
@@ -576,7 +576,7 @@ class UE9(Device):
             pass
         elif IOType == 1:
             #Digital Bit Write
-            if Dir == None or State == None:
+            if (Dir is None) or (State is None):
                 raise LabJackException("Need to specify a direction and state")
             command[4] = Dir
             command[5] = State
@@ -585,20 +585,20 @@ class UE9(Device):
             pass
         elif IOType == 3:
             #Digital Port Write
-            if Dir == None or State == None:
+            if (Dir is None) or (State is None):
                 raise LabJackException("Need to specify a direction and state")
             command[4] = Dir
             command[5] = State
         elif IOType == 4:
             #Analog In
-            if BipGain == None or Resolution == None or SettlingTime == None:
+            if (BipGain is None) or (Resolution is None) or (SettlingTime is None):
                 raise LabJackException("Need to specify a BipGain, Resolution, and SettlingTime")
             command[4] = BipGain
             command[5] = Resolution
             command[6] = SettlingTime
         elif IOType == 5:
             #Analog Out
-            if DAC == None:
+            if DAC is None:
                 raise LabJackException("Need to specify a DAC Value")
             command[4] = DAC & 0xff
             command[5] = (DAC >> 8) & 0xf
@@ -704,38 +704,38 @@ class UE9(Device):
         # Configure timers and counters if we are updating the configuration
         if UpdateConfig:
             if NumTimersEnabled >= 1:
-                if Timer0Mode == None: raise LabJackException("Need to specify a mode for Timer0")
-                if Timer0Value == None: raise LabJackException("Need to specify a value for Timer0")
+                if Timer0Mode is None: raise LabJackException("Need to specify a mode for Timer0")
+                if Timer0Value is None: raise LabJackException("Need to specify a value for Timer0")
                 command[10] = Timer0Mode
                 command[11] = Timer0Value & 0xff
                 command[12] = (Timer0Value >> 8) & 0xff
             if NumTimersEnabled >= 2:
-                if Timer1Mode == None: raise LabJackException("Need to specify a mode for Timer1")
-                if Timer1Value == None: raise LabJackException("Need to specify a value for Timer1")
+                if Timer1Mode is None: raise LabJackException("Need to specify a mode for Timer1")
+                if Timer1Value is None: raise LabJackException("Need to specify a value for Timer1")
                 command[13] = Timer1Mode
                 command[14] = Timer1Value & 0xff
                 command[15] = (Timer1Value >> 8) & 0xff
             if NumTimersEnabled >= 3:
-                if Timer2Mode == None: raise LabJackException("Need to specify a mode for Timer2")
-                if Timer2Value == None: raise LabJackException("Need to specify a value for Timer2")
+                if Timer2Mode is None: raise LabJackException("Need to specify a mode for Timer2")
+                if Timer2Value is None: raise LabJackException("Need to specify a value for Timer2")
                 command[16] = Timer2Mode
                 command[17] = Timer2Value & 0xff
                 command[18] = (Timer2Value >> 8) & 0xff
             if NumTimersEnabled >= 4:
-                if Timer3Mode == None: raise LabJackException("Need to specify a mode for Timer3")
-                if Timer3Value == None: raise LabJackException("Need to specify a value for Timer3")
+                if Timer3Mode is None: raise LabJackException("Need to specify a mode for Timer3")
+                if Timer3Value is None: raise LabJackException("Need to specify a value for Timer3")
                 command[19] = Timer3Mode
                 command[20] = Timer3Value & 0xff
                 command[21] = (Timer3Value >> 8) & 0xff
             if NumTimersEnabled >= 5:
-                if Timer4Mode == None: raise LabJackException("Need to specify a mode for Timer4")
-                if Timer4Value == None: raise LabJackException("Need to specify a value for Timer4")
+                if Timer4Mode is None: raise LabJackException("Need to specify a mode for Timer4")
+                if Timer4Value is None: raise LabJackException("Need to specify a value for Timer4")
                 command[22] = Timer4Mode
                 command[23] = Timer4Value & 0xff
                 command[24] = (Timer4Value >> 8) & 0xff
             if NumTimersEnabled == 6:
-                if Timer5Mode == None: raise LabJackException("Need to specify a mode for Timer5")
-                if Timer5Value == None: raise LabJackException("Need to specify a value for Timer5")
+                if Timer5Mode is None: raise LabJackException("Need to specify a mode for Timer5")
+                if Timer5Value is None: raise LabJackException("Need to specify a value for Timer5")
                 command[25] = Timer5Mode
                 command[26] = Timer5Value & 0xff
                 command[27] = (Timer5Value >> 8) & 0xff
@@ -931,8 +931,8 @@ class UE9(Device):
         if len(ChannelNumbers) != len(ChannelOptions):
             raise LabJackException("len(ChannelNumbers) doesn't match len(ChannelOptions)")
 
-        if ScanFrequency != None or SampleFrequency != None:
-            if ScanFrequency == None:
+        if (ScanFrequency is not None) or (SampleFrequency is not None):
+            if ScanFrequency is None:
                 ScanFrequency = SampleFrequency/NumChannels
             
             if ScanFrequency >= 11.5:
@@ -1500,7 +1500,7 @@ class UE9(Device):
         command[7] = SpeedAdjust
         command[8] = SDAPinNum
         command[9] = SCLPinNum
-        if AddressByte != None:
+        if AddressByte is not None:
             command[10] = AddressByte
         else:
             command[10] = Address << 1


### PR DESCRIPTION
This patch changes comparisons for `None` to use identity (`is` or `is not`) instead of equality (`==` or `!=`).  This is the idiomatic way to test for `None` in Python, and many existing comparisons in this project use identity already.  This is preferable because when equality is used,  an object may implement `__eq__` in a way that it returns `True` when compared with `== None`.