### PR TITLE
Replace deprecated has_key() with in

### DIFF
--- a/Examples/EI1050/ei1050.py
+++ b/Examples/EI1050/ei1050.py
@@ -147,8 +147,9 @@ class EI1050:
         Desc: Get a reading and create a Reading object with the information
         """
         if self.autoUpdate: self.update()
-        if self.curState.has_key('StatusCRC'): return Reading(self.curState['StatusReg'], self.curState['StatusCRC'], self.curState['Temperature'], self.curState['TemperatureCRC'], self.curState['Humidity'], self.curState['HumidityCRC'])
+        if 'StatusCRC' in self.curState: return Reading(self.curState['StatusReg'], self.curState['StatusCRC'], self.curState['Temperature'], self.curState['TemperatureCRC'], self.curState['Humidity'], self.curState['HumidityCRC'])
         else: return Reading(self.curState['StatusReg'], 0, self.curState['Temperature'], self.curState['TemperatureCRC'], self.curState['Humidity'], self.curState['HumidityCRC'])
+
     def update(self):
         """
         Name: EI1050.update()


### PR DESCRIPTION
`has_key` is deprecated in Python 2 and was removed in Python 3.