### PR TITLE
Remove raise statements with comma-separated args

### DIFF
--- a/src/u12.py
+++ b/src/u12.py
@@ -2890,7 +2890,7 @@ class U12(object):
         """
         
         if address is None:
-            raise Exception, "Must give an Address."
+            raise Exception("Must give an Address.")
         
         if idnum is None:
             idnum = self.id
@@ -2923,9 +2923,9 @@ class U12(object):
         >>> 1
         """
         if address is None or data is None:
-            raise Exception, "Must give both an Address and data."
+            raise Exception("Must give both an Address and data.")
         if type(data) is not list or len(data) != 4:
-            raise Exception, "Data must be a list and have a length of 4"
+            raise Exception("Data must be a list and have a length of 4")
         
         if idnum is None:
             idnum = self.id

--- a/src/u3.py
+++ b/src/u3.py
@@ -1597,7 +1597,7 @@ class U3(Device):
                 else:
                     return (bits * 0.000074463) * (0.000314 / 0.000037231) + -10.3
             else:
-                raise Exception, "Can't do differential on high voltage channels"
+                raise Exception("Can't do differential on high voltage channels")
     binaryToCalibratedAnalogVoltage.section = 3
     
     def binaryToCalibratedAnalogTemperature(self, bytesTemperature):


### PR DESCRIPTION
All exceptions raised in this project use `raise` with an exception instance, except for these few that use `raise` with comma-separated arguments.  Change these to use an exception instance as well, since the comma-separated format was removed in Python 3.