### PR TITLE
Allow parseline() to raise ValueError with info about why parsing failed

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -2906,17 +2906,13 @@ class LJSocketHandle(object):
 
         
 def parseline(line):
-    try:
-        prodId, crPort, modbusPort, spontPort, localId, serial = line.split(' ')
-        if not crPort.startswith('x'):
-            crPort = int(crPort)
-        if not modbusPort.startswith('x'):
-            modbusPort = int(modbusPort)
-        if not spontPort.startswith('x'):
-            spontPort = int(spontPort)
-            
-    except ValueError:
-        raise Exception("")
+    prodId, crPort, modbusPort, spontPort, localId, serial = line.split(' ')
+    if not crPort.startswith('x'):
+        crPort = int(crPort)
+    if not modbusPort.startswith('x'):
+        modbusPort = int(modbusPort)
+    if not spontPort.startswith('x'):
+        spontPort = int(spontPort)
     
     return { 'prodId' : int(prodId), 'crPort' : crPort, 'modbusPort' : modbusPort, 'spontPort' : spontPort, 'localId' : int(localId), 'serial' : int(serial)  }
 


### PR DESCRIPTION
`parseline()` catches `ValueError` only to raise an `Exception` with no message.  There is no reason to do this, and it causes information about why the exception occurred to be lost.

Since `ValueError` is an `Exception`, any code that might be depending on `parseline()` to raise `Exception` will still work unchanged.

    >>> isinstance(ValueError(), Exception)
    True
    >>> try:
    ...   raise ValueError()
    ... except Exception:
    ...   print("caught it")
    ... 
    caught it


