### PR TITLE
Replace xrange() with range()

### DIFF
--- a/Examples/outputSinDAC.py
+++ b/Examples/outputSinDAC.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
     # Print the current time, just to let you know something is happening.
     print "Start:", datetime.now()
     
-    for i in xrange(signalcount):
+    for i in range(signalcount):
         # Wait for signal to be received
         signal.pause()
         

--- a/Examples/u3Noise.py
+++ b/Examples/u3Noise.py
@@ -29,7 +29,7 @@ def calcNoiseAndResolution(d, positiveChannel = 0, negativeChannel = 31):
     
     cmd = u3.AIN(positiveChannel, negativeChannel, QuickSample = False, LongSettling = False)
     
-    for i in xrange(128):
+    for i in range(128):
         readings.append( float(d.getFeedback(cmd)[0])/16 )
     #print readings
     

--- a/Examples/u6Noise.py
+++ b/Examples/u6Noise.py
@@ -31,7 +31,7 @@ def calcNoiseAndResolution(d, resolutionIndex, voltageRange):
     start = datetime.now()
     
     # Collect 128 samples
-    for i in xrange(128):
+    for i in range(128):
         readings.append(d.getFeedback(cmd)[0]['AIN'])
     
     finish = datetime.now()

--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -1163,7 +1163,7 @@ def listAll(deviceType, connectionType = 1):
         
         deviceList = dict()
     
-        for i in xrange(pNumFound.value):
+        for i in range(pNumFound.value):
             if pSerialNumbers[i] != 1010:
                 deviceValue = dict(localId = pIDs[i], serialNumber = pSerialNumbers[i], ipAddress = DoubleToStringAddress(pAddresses[i]), devType = deviceType)
                 deviceList[pSerialNumbers[i]] = deviceValue
@@ -2683,7 +2683,7 @@ def __listAllUE9Unix(connectionType):
     if connectionType == LJ_ctUSB:
         numDevices = staticLib.LJUSB_GetDevCount(LJ_dtUE9)
     
-        for i in xrange(numDevices):
+        for i in range(numDevices):
             try:
                 device = openLabJack(LJ_dtUE9, 1, firstFound = False, devNumber = i+1)
                 device.close()
@@ -2752,7 +2752,7 @@ def __listAllU3Unix():
     deviceList = {}
     numDevices = staticLib.LJUSB_GetDevCount(LJ_dtU3)
 
-    for i in xrange(numDevices):
+    for i in range(numDevices):
         try:
             device = openLabJack(LJ_dtU3, 1, firstFound = False, devNumber = i+1)
             device.close()
@@ -2770,7 +2770,7 @@ def __listAllU6Unix():
     deviceList = {}
     numDevices = staticLib.LJUSB_GetDevCount(LJ_dtU6)
 
-    for i in xrange(numDevices):
+    for i in range(numDevices):
         try:
             device = openLabJack(LJ_dtU6, 1, firstFound = False, devNumber = i+1)
             device.close()
@@ -2786,7 +2786,7 @@ def __listAllBridgesUnix():
     deviceList = {}
     numDevices = staticLib.LJUSB_GetDevCount(0x501)
 
-    for i in xrange(numDevices):
+    for i in range(numDevices):
         try:
             device = openLabJack(0x501, 1, firstFound = False, devNumber = i+1)
             device.close()


### PR DESCRIPTION
`xrange()` was removed in Python 3 so replace it with `range()`, which works on both 2 and 3.  In all these cases, the argument to `xrange()` was a small number (and often very small), so there's not a negative impact on Python 2 by making this change. `Examples/outputSinDAC.py` is the largest (`signalcount` defaults to `2000`) but that's still small enough to not worry about and it's only an example file.