### PR TITLE
Import struct directly instead of through device modules

### DIFF
--- a/Examples/LJTickDAC/LJTickDAC.py
+++ b/Examples/LJTickDAC/LJTickDAC.py
@@ -4,6 +4,7 @@ Desc: A simple GUI application to demonstrate the usage of the I2C and
 LabJack Python modules to set the value of DACA and DACB in a LJ-TickDAC
 """
 import time
+import struct
 import sys
 from threading import Thread
 from Tkinter import *


### PR DESCRIPTION
LJTickDAC [uses `struct`](https://github.com/labjack/LabJackPython/blob/faa5f7e08c96e658df8d3bdfac021992e73296a5/Examples/LJTickDAC/LJTickDAC.py#L32) but does not import it.  `struct` just happens to get pulled in from the device modules (e.g. `from u3 import *`).  Add an explicit `import struct` instead. 
