### PR TITLE
Remove unused imports from stream tests

### DIFF
--- a/Examples/streamTest-threading.py
+++ b/Examples/streamTest-threading.py
@@ -13,12 +13,11 @@ about 40kHz.
 """
 
 import u3, u6, ue9, LabJackPython
-from time import sleep
 from datetime import datetime
-import struct
 import threading
 import Queue
-import ctypes, copy, sys
+import copy
+import sys
 
 # MAX_REQUESTS is the number of packets to be read.
 MAX_REQUESTS = 2500

--- a/Examples/streamTest.py
+++ b/Examples/streamTest.py
@@ -1,7 +1,5 @@
 import u3, u6, ue9
-from time import sleep
 from datetime import datetime
-import struct
 import traceback
 
 # MAX_REQUESTS is the number of packets to be read.


### PR DESCRIPTION
These modules are imported but never used (not even by the commented out code).
