### PR TITLE
Fix imports for py3

### DIFF
--- a/Examples/EI1050/ei1050.py
+++ b/Examples/EI1050/ei1050.py
@@ -5,6 +5,7 @@ Desc: A few simple classes to handle communication with the EI1050 probe
 import threading
 import time
 import sys
+
 import u3
 import u6
 import ue9

--- a/Examples/EI1050/ei1050.py
+++ b/Examples/EI1050/ei1050.py
@@ -2,9 +2,9 @@
 Name: EI1050
 Desc: A few simple classes to handle communication with the EI1050 probe
 """
+import sys
 import threading
 import time
-import sys
 
 import u3
 import u6

--- a/Examples/EI1050/ei1050SampleApp.py
+++ b/Examples/EI1050/ei1050SampleApp.py
@@ -5,9 +5,21 @@ LabJack Python modules. For an example of using the Labjack Python module direct
 look at the source code of ei1050.py
 """
 import sys
-from Queue import Queue
-from Tkinter import *
-import tkMessageBox
+
+try:
+    from Queue import Queue
+except ImportError: # Python 3
+    from queue import Queue
+
+try:
+    from Tkinter import *
+except ImportError: # Python 3
+    from tkinter import *
+
+try:
+    import tkMessageBox
+except ImportError: # Python 3
+    import tkinter.messagebox as tkMessageBox
 
 try:
     import LabJackPython

--- a/Examples/PWM-looping.py
+++ b/Examples/PWM-looping.py
@@ -6,8 +6,11 @@ For the complete modbus map, visit the Modbus support page:
 Note: Low-level commands that are commented out work only for U6/U3. UE9 is a
       little more complicated.
 """
-import u3, u6, ue9
 from time import sleep
+
+import u3
+import u6
+import ue9
 
 # Open the LabJack. Comment out all but one of these:
 d = ue9.UE9()

--- a/Examples/dca10.py
+++ b/Examples/dca10.py
@@ -3,7 +3,10 @@ A class to make working with the DCA-10 easier. More info on the DCA-10 here:
 
 http://labjack.com/support/dca-10/datasheet
 """
-import LabJackPython, u3, u6, ue9
+import LabJackPython
+import u3
+import u6
+import ue9
 
 U3_WIRING_DESCRIPTION = """
 Connection on DCA-10 -> Connection on LabJack

--- a/Examples/dca10Example.py
+++ b/Examples/dca10Example.py
@@ -5,10 +5,9 @@ http://labjack.com/support/dca-10/datasheet
 
 See the dca10.py for more information on the DCA10 class.
 """
-import dca10
-from time import sleep
-from time import time
+from time import sleep, time
 
+import dca10
 
 r = raw_input("Do you have an encoder to connect to the LabJack? [y/N] ")
 

--- a/Examples/ktypeExample.py
+++ b/Examples/ktypeExample.py
@@ -1,5 +1,7 @@
-import u6, ue9
 from time import sleep
+
+import u6
+import ue9
 
 # Coefficients
 

--- a/Examples/outputSinDAC.py
+++ b/Examples/outputSinDAC.py
@@ -13,6 +13,13 @@
 # can result in strange behavior. Try to keep the period (1/frequency) much
 # greater than update interval.
 
+import math # For sin function
+import signal # For timing
+from datetime import datetime # For printing times
+
+import u3
+import u6
+import ue9
 
 # Constants. Change these to change the results:
 
@@ -21,12 +28,6 @@ UPDATE_INTERVAL = 0.005
 
 # The frequency of the sine wave, in Hz
 FREQUENCY = 10
-
-# Imports:
-import u3, u6, ue9 # For working with the U3
-import signal # For timing
-import math # For sin function
-from datetime import datetime # For printing times
 
 if __name__ == '__main__':
     print "This program will attempt to generate a sine wave with a frequency of %s Hz, updating once every %s seconds." % (FREQUENCY, UPDATE_INTERVAL)

--- a/Examples/spi_sca3000.py
+++ b/Examples/spi_sca3000.py
@@ -26,9 +26,8 @@ The default SPI settings for a U3 are:
 Note the CSPINNum, CLKPinNum, MISOPinNum, and MOSIPinNum pin numbers and make
 your connections accordingly.
 """
-
-import time
 import os
+import time
 
 #By default the example uses a UE9. Uncomment the U6 or U3 section if that is
 #your device and then comment out the UE9 section.

--- a/Examples/streamTest-threading.py
+++ b/Examples/streamTest-threading.py
@@ -12,12 +12,16 @@ On a Mac OS 10.5 machine with a 1.42 GHz G4 Processor, we saw max speeds of
 about 40kHz.
 """
 
-import u3, u6, ue9, LabJackPython
-from datetime import datetime
-import threading
-import Queue
 import copy
+import Queue
 import sys
+import threading
+from datetime import datetime
+
+import LabJackPython
+import u3
+import u6
+import ue9
 
 # MAX_REQUESTS is the number of packets to be read.
 MAX_REQUESTS = 2500

--- a/Examples/streamTest-threading.py
+++ b/Examples/streamTest-threading.py
@@ -13,10 +13,14 @@ about 40kHz.
 """
 
 import copy
-import Queue
 import sys
 import threading
 from datetime import datetime
+
+try:
+  import Queue
+except ImportError: # Python 3
+  import queue as Queue
 
 import LabJackPython
 import u3

--- a/Examples/streamTest.py
+++ b/Examples/streamTest.py
@@ -1,6 +1,9 @@
-import u3, u6, ue9
-from datetime import datetime
 import traceback
+from datetime import datetime
+
+import u3
+import u6
+import ue9
 
 # MAX_REQUESTS is the number of packets to be read.
 MAX_REQUESTS = 75

--- a/Examples/u3Noise.py
+++ b/Examples/u3Noise.py
@@ -23,6 +23,11 @@ On with the test:
 
 import math
 
+try:
+    raw_input
+except NameError: # Python 3
+    raw_input = input
+
 import u3
 
 def calcNoiseAndResolution(d, positiveChannel = 0, negativeChannel = 31):

--- a/Examples/u3Noise.py
+++ b/Examples/u3Noise.py
@@ -21,8 +21,9 @@ You'll find that by comparing the two results, the LabJack is rarely the reason 
 On with the test:
 """
 
-import u3
 import math
+
+import u3
 
 def calcNoiseAndResolution(d, positiveChannel = 0, negativeChannel = 31):
     readings = []

--- a/Examples/u3SampleAndLogToCloudDot.py
+++ b/Examples/u3SampleAndLogToCloudDot.py
@@ -25,8 +25,13 @@
 
 import signal
 from datetime import datetime
+
+try:
+    from urllib import urlencode
+except ImportError: # Python 3
+    from urllib.parse import urlencode
+
 from httplib2 import Http
-from urllib import urlencode
 
 import u3
 

--- a/Examples/u3SampleAndLogToCloudDot.py
+++ b/Examples/u3SampleAndLogToCloudDot.py
@@ -23,6 +23,13 @@
 # For information on the CloudDot REST API, visit: 
 #     http://labjack.com/support/clouddot/rest-api
 
+import signal
+from datetime import datetime
+from httplib2 import Http
+from urllib import urlencode
+
+import u3
+
 # Replace these three fields
 CLOUDDOT_USERNAME = ""
 CLOUDDOT_API_KEY  = "01234567890123456789"
@@ -30,13 +37,6 @@ CLOUDDOT_CHANNEL  = "Temperature"
 
 SAMPLE_INTERVAL   = 30 # Sample and post to CloudDot after this time in seconds
 MODBUS_REGISTER   = 0  # Read from this register to get the data. See http://labjack.com/support/modbus
-
-import u3
-import signal
-from datetime import datetime
-
-from httplib2 import Http
-from urllib import urlencode
 
 def sampleAndPost(*args):
     print "----- Gathering sample at", datetime.now()

--- a/Examples/u3allio.py
+++ b/Examples/u3allio.py
@@ -1,8 +1,9 @@
 # Based on u3allio.c
 
-import u3
-from datetime import datetime
 import sys
+from datetime import datetime
+
+import u3
 
 numChannels = int(sys.argv[1])
 quickSample = 1

--- a/Examples/u6Noise.py
+++ b/Examples/u6Noise.py
@@ -5,9 +5,10 @@ Desc: An example program that will calculate the values that can be found in
       Appendix B of the U6 User's Guide.
 """
 
-import u6 # Import the u6 class
 import math # Need math for square root and log.
 from datetime import datetime
+
+import u6 # Import the u6 class
 
 # The size of the various ranges
 ranges = [20, 2, 0.2, 0.02]

--- a/Examples/u6Noise.py
+++ b/Examples/u6Noise.py
@@ -8,7 +8,7 @@ Desc: An example program that will calculate the values that can be found in
 import math # Need math for square root and log.
 from datetime import datetime
 
-import u6 # Import the u6 class
+import u6 # Import the u6 module
 
 # The size of the various ranges
 ranges = [20, 2, 0.2, 0.02]

--- a/Examples/u6allio.py
+++ b/Examples/u6allio.py
@@ -1,8 +1,9 @@
 # Based on u6allio.c
 
-import u6
-from datetime import datetime
 import sys
+from datetime import datetime
+
+import u6
 
 numChannels = int(sys.argv[1])
 resolutionIndex = 1

--- a/Examples/workingWithModbus.py
+++ b/Examples/workingWithModbus.py
@@ -5,9 +5,11 @@
 " Be sure to check out the Modbus map (http://labjack.com/support/modbus) for a
 " full list of registers.
 """
-
-import u3, u6, ue9
 import random
+
+import u3
+import u6
+import ue9
 
 if __name__ == '__main__':
     print "This program shows how to work with modbus and your device. Registers are taken directly from the Modbus map (http://labjack.com/support/modbus).\n"

--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -9,16 +9,18 @@ inherit from.
 
 A typical user should start with their device's module, such as u3.py.
 """
-# We use the 'with' keyword to manage the thread-safe device lock. It's built-in on 2.6; 2.5 requires an import.
+# We use the 'with' keyword to manage the thread-safe device lock. 
+# It's built-in on 2.6; 2.5 requires an import.
 from __future__ import with_statement
 
-import struct
-import socket
-import Modbus
 import atexit # For auto-closing devices
-import threading # For a thread-safe device lock
 import ctypes
+import socket
+import struct
+import threading # For a thread-safe device lock
 import sys
+
+import Modbus
 
 LABJACKPYTHON_VERSION = "4-24-2014"
 

--- a/src/Modbus.py
+++ b/src/Modbus.py
@@ -3,10 +3,9 @@
 # Created: 05.05.2008
 
 from __future__ import with_statement
-from threading import Lock
-
-from struct import pack, unpack #, unpack_from  # unpack_from is new in 2.5
 from datetime import datetime
+from struct import pack, unpack
+from threading import Lock
 
 AES_CHANNEL               = 64000
 IP_PART1_CHANNEL          = 64008

--- a/src/skymote.py
+++ b/src/skymote.py
@@ -3,8 +3,9 @@ Name: skymote.py
 Desc: Provides a Bridge and Mote class for working with SkyMote bridges and 
       motes.
 """
-from LabJackPython import *
 import sys
+
+from LabJackPython import *
 
 if sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
     if skymoteLib is None:

--- a/src/u12.py
+++ b/src/u12.py
@@ -23,12 +23,12 @@ Desc: Defines the U12 class, which makes working with a U12 much easier. The
       
 """
 
-import ctypes
 import atexit
+import ctypes
 import math
-from time import time
 import struct
 import sys
+from time import time
 
 _os_name = "" #Set to "nt" or "posix" in _loadLibrary
 

--- a/src/u3.py
+++ b/src/u3.py
@@ -17,9 +17,13 @@ Section Number Mapping:
 
 """
 import collections
-import ConfigParser
 import struct
 import sys
+
+try:
+    import ConfigParser
+except ImportError: # Python 3
+    import configparser as ConfigParser
 
 from LabJackPython import *
 

--- a/src/u3.py
+++ b/src/u3.py
@@ -16,8 +16,12 @@ Section Number Mapping:
 4 = Private Helper Functions
 
 """
+import collections
+import ConfigParser
+import struct
+import sys
+
 from LabJackPython import *
-import collections, struct, ConfigParser, sys
 
 FIO0, FIO1, FIO2, FIO3, FIO4, FIO5, FIO6, FIO7, \
 EIO0, EIO1, EIO2, EIO3, EIO4, EIO5, EIO6, EIO7, \

--- a/src/u6.py
+++ b/src/u6.py
@@ -10,9 +10,12 @@ Guide:
 
 http://labjack.com/support/u6/users-guide/5.2
 """
-from LabJackPython import *
+import collections
+import struct
+import ConfigParser
+import sys
 
-import collections, struct, ConfigParser, sys
+from LabJackPython import *
 
 def openAllU6():
     """

--- a/src/u6.py
+++ b/src/u6.py
@@ -12,8 +12,12 @@ http://labjack.com/support/u6/users-guide/5.2
 """
 import collections
 import struct
-import ConfigParser
 import sys
+
+try:
+    import ConfigParser
+except ImportError: # Python 3
+    import configparser as ConfigParser
 
 from LabJackPython import *
 

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -10,11 +10,15 @@ To learn about the low-level functions, please see Section 5.2 of the UE9 User's
 http://labjack.com/support/ue9/users-guide/5.2 
 """
 import collections
-import ConfigParser
 import select
 import socket
 import struct
 from datetime import datetime
+
+try:
+  import ConfigParser
+except ImportError: # Python 3
+  import configparser as ConfigParser
 
 from LabJackPython import *
 

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -9,10 +9,14 @@ To learn about the low-level functions, please see Section 5.2 of the UE9 User's
 
 http://labjack.com/support/ue9/users-guide/5.2 
 """
-from LabJackPython import *
-
-import collections, struct, socket, select, ConfigParser
+import collections
+import ConfigParser
+import select
+import socket
+import struct
 from datetime import datetime
+
+from LabJackPython import *
 
 def openAllUE9():
     """


### PR DESCRIPTION
Separate stdlib imports from the others so it's clear what comes from stdlib, then fix stdlib imports so they are compatible with Python 2 and 3.