### PR TITLE
Fix concatenation of range and list for Python 3

### DIFF
--- a/src/u3.py
+++ b/src/u3.py
@@ -1982,7 +1982,7 @@ class AIN(FeedbackCommand):
         self.longSettling = LongSettling
         self.quickSample = QuickSample
         
-        validChannels = range(16) + [30, 31]
+        validChannels = list(range(16)) + [30, 31]
         if PositiveChannel not in validChannels:
             raise Exception("Invalid Positive Channel specified")
         if NegativeChannel not in validChannels:


### PR DESCRIPTION
On Python 2, `range()` returns a `list`.  On Python 3, `range()` returns a `range`.  A `range` can't be concatenated to a `list`.  Convert it to a `list` so this code works on Python 2 and 3.