### PR TITLE
Remove unused variable 'r' from getDevCounts()

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -1230,7 +1230,7 @@ def getDevCounts():
         devCounts = (ctypes.c_uint*NUMBER_OF_UNIQUE_LABJACK_PRODUCT_IDS)()
         devIds = (ctypes.c_uint*NUMBER_OF_UNIQUE_LABJACK_PRODUCT_IDS)()
         n = ctypes.c_uint(NUMBER_OF_UNIQUE_LABJACK_PRODUCT_IDS)
-        r = staticLib.LJUSB_GetDevCounts(ctypes.byref(devCounts), ctypes.byref(devIds), n)
+        staticLib.LJUSB_GetDevCounts(ctypes.byref(devCounts), ctypes.byref(devIds), n)
         
         returnDict = dict()
         


### PR DESCRIPTION
The local `r` is assigned to but not used.  The return value from `LJUSB_GetDevCounts` is not an error code, it's all products counted.  Since that count is not used by this code, we can just remove `r`.