### PR TITLE
Remove "import *" from device modules

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -17,8 +17,8 @@ import atexit # For auto-closing devices
 import ctypes
 import socket
 import struct
-import threading # For a thread-safe device lock
 import sys
+import threading # For a thread-safe device lock
 
 import Modbus
 

--- a/src/skymote.py
+++ b/src/skymote.py
@@ -7,7 +7,11 @@ import socket
 import struct
 import sys
 
-from LabJackPython import *
+from LabJackPython import (
+    Device,
+    LabJackException,
+    skymoteLib,
+    )
 
 if sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
     if skymoteLib is None:

--- a/src/u3.py
+++ b/src/u3.py
@@ -25,7 +25,16 @@ try:
 except ImportError: # Python 3
     import configparser as ConfigParser
 
-from LabJackPython import *
+from LabJackPython import (
+    Device,
+    deviceCount,
+    LabJackException,
+    LowlevelErrorException,
+    lowlevelErrorToString,
+    MAX_USB_PACKET_LENGTH,
+    setChecksum8,
+    toDouble,
+    )
 
 FIO0, FIO1, FIO2, FIO3, FIO4, FIO5, FIO6, FIO7, \
 EIO0, EIO1, EIO2, EIO3, EIO4, EIO5, EIO6, EIO7, \

--- a/src/u6.py
+++ b/src/u6.py
@@ -19,7 +19,16 @@ try:
 except ImportError: # Python 3
     import configparser as ConfigParser
 
-from LabJackPython import *
+from LabJackPython import (
+    Device,
+    deviceCount,
+    LabJackException,
+    LowlevelErrorException,
+    lowlevelErrorToString,
+    MAX_USB_PACKET_LENGTH,
+    setChecksum8,
+    toDouble,
+    )
 
 def openAllU6():
     """

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -20,7 +20,18 @@ try:
 except ImportError: # Python 3
   import configparser as ConfigParser
 
-from LabJackPython import *
+from LabJackPython import (
+    Device,
+    deviceCount,
+    LabJackException,
+    LJ_tcSYS,
+    LowlevelErrorException,
+    lowlevelErrorToString,
+    setChecksum8,
+    toDouble,
+    UE9TCPHandle,
+    verifyChecksum,
+    )
 
 def openAllUE9():
     """


### PR DESCRIPTION
This change removes `from LabJackPython import *` from the device modules.  Each module now explicitly imports only the pieces it needs from `LabJackPython`.

Here are some reasons why this is very desirable:

 - Static analysis tools like pyflakes can't detect undefined names when `import *` is used.  Finding undefined names has resulted in [a number of bug fixes](https://github.com/labjack/LabJackPython/issues?q=%22undefined+name%22).

 - `import *` can result in modules having hidden dependencies like 81f2786a447b32a5ae59f7bc817f7e7ffad6be6b, c77cf5eb2de6b4fb053cd86533fafc2cbcc3bc5f, and 17ee40a9e9db4206e70556dbdbc65a96d395454d.

 - By removing `import *`, the intended API of each device module is clarified for end users.  