### PR TITLE
Multiple fixes to use floor division for Python 3

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -252,10 +252,10 @@ class Device(object):
                 dataWords = len(writeBuffer)
                 writeBuffer = [0, 0xF8, 0, 0x07, 0, 0] + writeBuffer #modbus low-level function
                 if dataWords % 2 != 0:
-                    dataWords = (dataWords+1)/2
+                    dataWords = (dataWords+1)//2
                     writeBuffer.append(0)
                 else:
-                    dataWords = dataWords/2
+                    dataWords = dataWords//2
                 writeBuffer[2] = dataWords
                 setChecksum(writeBuffer)
             elif modbus is True and self.modbusPrependZeros:

--- a/src/Modbus.py
+++ b/src/Modbus.py
@@ -272,7 +272,7 @@ def calcNumberOfRegistersAndFormat(addr, numReg = None):
 
     if numReg:
         if (numReg%minNumReg) == 0:
-            return (numReg, '>' + ( format * (numReg/minNumReg) ))
+            return (numReg, '>' + ( format * (numReg//minNumReg) ))
         else:
             raise ModbusException("For address %s, the number of registers must be divisible by %s" % (addr, minNumReg))
     else:

--- a/src/Modbus.py
+++ b/src/Modbus.py
@@ -100,7 +100,7 @@ def readHoldingRegistersResponse(packet, payloadFormat=None):
         raise ModbusException("Packet length not valid. Expected %s, Got %s\n\nThe packet you received: %s" % (payloadLength + HEADER_LENGTH, len(packet), repr(packet)))
 
     if payloadFormat is None:
-        payloadFormat = '>' + 'H' * (payloadLength/2)
+        payloadFormat = '>' + 'H' * (payloadLength//2)
 
     # When we write '>s', we mean a variable-length string.
     # We just didn't know the length when we wrote it.
@@ -159,7 +159,7 @@ def readInputRegistersResponse(packet, payloadFormat=None):
         raise ModbusException("Packet length not valid.")
 
     if payloadFormat is None:
-        payloadFormat = '>' + 'H' * (payloadLength/2)
+        payloadFormat = '>' + 'H' * (payloadLength//2)
 
     # When we write '>s', we mean a variable-length string.
     # We just didn't know the length when we wrote it.

--- a/src/u3.py
+++ b/src/u3.py
@@ -742,7 +742,7 @@ class U3(Device):
         sendBuffer, readLen = self._buildBuffer(sendBuffer, readLen, commandlist)
         if len(sendBuffer) % 2:
             sendBuffer += [0]
-        sendBuffer[2] = len(sendBuffer) / 2 - 3
+        sendBuffer[2] = len(sendBuffer) // 2 - 3
         
         if readLen % 2:
             readLen += 1
@@ -1002,10 +1002,10 @@ class U3(Device):
                 if ScanFrequency < 25:
                     SamplesPerPacket = ScanFrequency
                 DivideClockBy256 = True
-                ScanInterval = 15625/ScanFrequency
+                ScanInterval = 15625//ScanFrequency
             else:
                 DivideClockBy256 = False
-                ScanInterval = 4000000/ScanFrequency
+                ScanInterval = 4000000//ScanFrequency
         
         # Force Scan Interval into correct range
         ScanInterval = min( ScanInterval, 65535 )
@@ -1235,7 +1235,7 @@ class U3(Device):
         
         #command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 4 + (numSPIBytes/2)
+        command[2] = 4 + (numSPIBytes//2)
         command[3] = 0x3A
         #command[4] = Checksum16 (LSB)
         #command[5] = Checksum16 (MSB)
@@ -1309,9 +1309,9 @@ class U3(Device):
         
         #command[8] = Reserved
         if olderHardware:
-            command[9] = (2**8) - self.timerClockBase/DesiredBaud
+            command[9] = (2**8) - self.timerClockBase//DesiredBaud
         else:
-            BaudFactor = (2**16) - 48000000/(2 * DesiredBaud)
+            BaudFactor = (2**16) - 48000000//(2 * DesiredBaud)
             t = struct.pack("<H", BaudFactor)
             command[8] = ord(t[0])
             command[9] = ord(t[1])
@@ -1374,7 +1374,7 @@ class U3(Device):
         
         #command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 1 + ( numBytes/2 )
+        command[2] = 1 + ( numBytes//2 )
         command[3] = 0x15
         #command[4] = Checksum16 (LSB)
         #command[5] = Checksum16 (MSB)
@@ -1461,7 +1461,7 @@ class U3(Device):
         
         #command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 4 + (numBytes/2)
+        command[2] = 4 + (numBytes//2)
         command[3] = 0x3B
         #command[4] = Checksum16 (LSB)
         #command[5] = Checksum16 (MSB)

--- a/src/u6.py
+++ b/src/u6.py
@@ -428,7 +428,7 @@ class U6(Device):
 
         if len(sendBuffer) % 2:
             sendBuffer += [0]
-        sendBuffer[2] = len(sendBuffer) / 2 - 3
+        sendBuffer[2] = len(sendBuffer) // 2 - 3
         
         if readLen % 2:
             readLen += 1


### PR DESCRIPTION
When the division operator `/` is used with two `int`s, an `int` is returned on Python 2 but a `float` is returned on Python 3.  The floor division operator `//` returns an `int` on both 2 and 3.