### PR TITLE
Remove unused import

### DIFF
--- a/Examples/streamTest-threading.py
+++ b/Examples/streamTest-threading.py
@@ -22,7 +22,6 @@ try:
 except ImportError: # Python 3
   import queue as Queue
 
-import LabJackPython
 import u3
 import u6
 import ue9


### PR DESCRIPTION
`LabJackPython` is imported but never used, not even by the commented out code.