### PR TITLE
Wrap devs.keys() in list() for Python 3 compatibility

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -1293,7 +1293,7 @@ def _openLabJackUsingLJSocket(deviceType, firstFound, pAddress, LJSocket, handle
 def _openLabJackUsingUDDriver(deviceType, connectionType, firstFound, pAddress, devNumber ):
     if devNumber is not None:
         devs = listAll(deviceType)
-        pAddress = devs.keys()[(devNumber-1)]
+        pAddress = list(devs.keys())[devNumber-1]
     
     handle = ctypes.c_long()
     pAddress = str(pAddress)


### PR DESCRIPTION
On Python 2, `devs.keys()` returns a `list`.  On Python 3, `devs.keys()` returns a `dict_keys`, which is not indexable.  Wrap it in a `list` so this code works on 2 and 3.