### PR TITLE
Show a friendlier error when SPIMode is invalid

### DIFF
--- a/src/u12.py
+++ b/src/u12.py
@@ -1681,7 +1681,6 @@ class U12(object):
         
         return returnDict
         
-    SPIModes = ['A', 'B', 'C', 'D']
     def rawSPI(self, Data, AddMsDelay = False, AddHundredUsDelay = False, SPIMode = 'A', NumberOfBytesToWriteRead = 0, ControlCS = False, StateOfActiveCS = False, CSLineNumber = 0):
         """
         Name: U12.rawSPI( Data, AddMsDelay = False, AddHundredUsDelay = False,
@@ -1740,7 +1739,11 @@ class U12(object):
         bf.bit7 = int(bool(AddMsDelay))
         bf.bit6 = int(bool(AddHundredUsDelay))
         
-        modeIndex = self.SPIModes.index(SPIMode)
+        spiModes = ('A', 'B', 'C', 'D')
+        try:
+            modeIndex = spiModes.index(SPIMode)
+        except ValueError:
+            raise U12Exception("Invalid SPIMode %r, valid modes are: %r" % (SPIMode, spiModes))
         bf[7-modeIndex] = 1
         
         command[4] = int(bf)

--- a/src/u3.py
+++ b/src/u3.py
@@ -1203,7 +1203,6 @@ class U3(Device):
         return watchdogStatus
     watchdog.section = 2
 
-    SPIModes = { 'A' : 0, 'B' : 1, 'C' : 2, 'D' : 3 }
     def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPINNum = 4, CLKPinNum = 5, MISOPinNum = 6, MOSIPinNum = 7):
         """
         Name: U3.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
@@ -1245,7 +1244,12 @@ class U3(Device):
         if DisableDirConfig:
             command[6] |= (1 << 6)
         
-        command[6] |= ( self.SPIModes[SPIMode] & 3 )
+        spiModes = ('A', 'B', 'C', 'D')
+        try:
+            modeIndex = spiModes.index(SPIMode)
+        except ValueError:
+            raise LabJackException("Invalid SPIMode %r, valid modes are: %r" % (SPIMode, spiModes))
+        command[6] |= modeIndex
         
         command[7] = SPIClockFactor
         #command[8] = Reserved

--- a/src/u6.py
+++ b/src/u6.py
@@ -803,7 +803,6 @@ class U6(Device):
         
         return watchdogStatus
 
-    SPIModes = { 'A' : 0, 'B' : 1, 'C' : 2, 'D' : 3 }
     def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPINNum = 0, CLKPinNum = 1, MISOPinNum = 2, MOSIPinNum = 3):
         """
         Name: U6.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
@@ -851,7 +850,12 @@ class U6(Device):
         if DisableDirConfig:
             command[6] |= (1 << 6)
         
-        command[6] |= ( self.SPIModes[SPIMode] & 3 )
+        spiModes = ('A', 'B', 'C', 'D')
+        try:
+            modeIndex = spiModes.index(SPIMode)
+        except ValueError:
+            raise LabJackException("Invalid SPIMode %r, valid modes are: %r" % (SPIMode, spiModes))
+        command[6] |= modeIndex
         
         command[7] = SPIClockFactor
         #command[8] = Reserved


### PR DESCRIPTION
Remove public `SPIModes`, which is used only for validation and is not part of the API.  

Add a friendlier error message if the `SPIMode` kwarg is invalid.