### PR TITLE
Declare _use_ptr as global in _loadLibrary(), otherwise it isn't updated

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -115,6 +115,7 @@ def _loadLibrary():
     Returns a ctypes dll pointer to the library.
     """
     global _os_name
+    global _use_ptr
 
     _os_name = "nt"
     try:


### PR DESCRIPTION
`_loadLibrary()` intends to change `_use_ptr` at module level but creates an unused local instead.