### PR TITLE
Add comment to warn about import order.

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -15,7 +15,7 @@ from __future__ import with_statement
 
 import atexit # For auto-closing devices
 import socket
-import ctypes
+import ctypes # import after socket or cygwin crashes "Aborted (core dump)"
 import struct
 import sys
 import threading # For a thread-safe device lock


### PR DESCRIPTION
Add a comment about the import order so we don't break it in refactoring later.