### PR TITLE
Rename 'CSPINNum' to 'CSPinNum' for consistency with other kwargs

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -261,3 +261,7 @@ Version History
     - Fixed the reset method for LabJackPython module's Device class.
     - Updated the reset method of the Device class to perform a hard and soft
       reset on Linux and Mac OS X like the Windows UD function ResetLabJack.
+    - The spi() method of U3, U6, and UE9 has changed.  The keyword argument
+      "CSPINNum" has been renamed to "CSPinNum" to be consistent with the other
+      keyword arguments.  The old "CSPINNum" will still work but is deprecated
+      and will be removed in a future version.

--- a/Examples/spi_sca3000.py
+++ b/Examples/spi_sca3000.py
@@ -8,22 +8,22 @@ AppNote online:
 The default SPI settings for a UE9 are:
 
   AutoCS = True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0,
-  CSPINNum = 1 (FIO1), CLKPinNum = 0 (FIO0), MISOPinNum = 3 (FIO3),
+  CSPinNum = 1 (FIO1), CLKPinNum = 0 (FIO0), MISOPinNum = 3 (FIO3),
   MOSIPinNum = 2 (FIO2)
 
 The default SPI settings for a U6 are:
 
   AutoCS = True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0,
-  CSPINNum = 0 (FIO0), CLKPinNum = 1 (FIO1), MISOPinNum = 2 (FIO2),
+  CSPinNum = 0 (FIO0), CLKPinNum = 1 (FIO1), MISOPinNum = 2 (FIO2),
   MOSIPinNum = 3 (FIO3)
 
 The default SPI settings for a U3 are:
 
   AutoCS = True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0,
-  CSPINNum = 4 (FIO4), CLKPinNum = 5 (FIO5), MISOPinNum = 6 (FIO6),
+  CSPinNum = 4 (FIO4), CLKPinNum = 5 (FIO5), MISOPinNum = 6 (FIO6),
   MOSIPinNum = 7 (FIO7)
 
-Note the CSPINNum, CLKPinNum, MISOPinNum, and MOSIPinNum pin numbers and make
+Note the CSPinNum, CLKPinNum, MISOPinNum, and MOSIPinNum pin numbers and make
 your connections accordingly.
 """
 import os

--- a/src/u3.py
+++ b/src/u3.py
@@ -19,6 +19,7 @@ Section Number Mapping:
 import collections
 import struct
 import sys
+import warnings
 
 try:
     import ConfigParser
@@ -1203,10 +1204,10 @@ class U3(Device):
         return watchdogStatus
     watchdog.section = 2
 
-    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPINNum = 4, CLKPinNum = 5, MISOPinNum = 6, MOSIPinNum = 7):
+    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 4, CLKPinNum = 5, MISOPinNum = 6, MOSIPinNum = 7, CSPINNum = None):
         """
         Name: U3.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
-                     SPIMode = 'A', SPIClockFactor = 0, CSPINNum = 4,
+                     SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 4,
                      CLKPinNum = 5, MISOPinNum = 6, MOSIPinNum = 7)
         
         Args: SPIBytes, a list of bytes to be transferred.
@@ -1217,11 +1218,16 @@ class U3(Device):
 
         NOTE: Requires U3 hardware version 1.21 or greater.  Also,
               the return has been changed to a dictionary with
-              NumSPIBytesTransferred and SPIBytes.
+              NumSPIBytesTransferred and SPIBytes.  The keyword
+              argument CSPinNum was named CSPINNum in old versions.
         """
         if not isinstance(SPIBytes, list):
             raise LabJackException("SPIBytes MUST be a list of bytes")
-        
+
+        if CSPINNum is not None:
+            warnings.warn("CSPINNum is deprecated, use CSPinNum instead", DeprecationWarning)
+            CSPinNum = CSPINNum
+
         numSPIBytes = len(SPIBytes)
         
         oddPacket = False
@@ -1253,7 +1259,7 @@ class U3(Device):
         
         command[7] = SPIClockFactor
         #command[8] = Reserved
-        command[9] = CSPINNum
+        command[9] = CSPinNum
         command[10] = CLKPinNum
         command[11] = MISOPinNum
         command[12] = MOSIPinNum

--- a/src/u6.py
+++ b/src/u6.py
@@ -13,6 +13,7 @@ http://labjack.com/support/u6/users-guide/5.2
 import collections
 import struct
 import sys
+import warnings
 
 try:
     import ConfigParser
@@ -797,10 +798,10 @@ class U6(Device):
         
         return watchdogStatus
 
-    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPINNum = 0, CLKPinNum = 1, MISOPinNum = 2, MOSIPinNum = 3):
+    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 0, CLKPinNum = 1, MISOPinNum = 2, MOSIPinNum = 3, CSPINNum = None):
         """
         Name: U6.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
-                     SPIMode = 'A', SPIClockFactor = 0, CSPINNum = 0,
+                     SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 0,
                      CLKPinNum = 1, MISOPinNum = 2, MOSIPinNum = 3)
         
         Args: SPIBytes, A list of bytes to send.
@@ -811,16 +812,23 @@ class U6(Device):
                                 of the line.
               SPIMode, 'A', 'B', 'C',  or 'D'. 
               SPIClockFactor, Sets the frequency of the SPI clock.
-              CSPINNum, which pin is CS
+              CSPinNum, which pin is CS
               CLKPinNum, which pin is CLK
               MISOPinNum, which pin is MISO
               MOSIPinNum, which pin is MOSI
         
         Desc: Sends and receives serial data using SPI synchronous
               communication. See Section 5.2.17 of the user's guide.
+
+        NOTE: The keyword argument CSPinNum was named CSPINNum in
+              old versions.
         """
         if not isinstance(SPIBytes, list):
             raise LabJackException("SPIBytes MUST be a list of bytes")
+
+        if CSPINNum is not None:
+            warnings.warn("CSPINNum is deprecated, use CSPinNum instead", DeprecationWarning)
+            CSPinNum = CSPINNum
         
         numSPIBytes = len(SPIBytes)
         
@@ -853,7 +861,7 @@ class U6(Device):
         
         command[7] = SPIClockFactor
         #command[8] = Reserved
-        command[9] = CSPINNum
+        command[9] = CSPinNum
         command[10] = CLKPinNum
         command[11] = MISOPinNum
         command[12] = MOSIPinNum

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -14,6 +14,7 @@ import datetime
 import select
 import socket
 import struct
+import warnings
 
 try:
   import ConfigParser
@@ -1289,10 +1290,10 @@ class UE9(Device):
         return { 'UpdateDAC0onTimeout' : bool(result[7]& 1), 'UpdateDAC1onTimeout' : bool((result[7] >> 1) & 1), 'UpdateDigitalIOAonTimeout' : bool((result[7] >> 3) & 1), 'UpdateDigitalIOBonTimeout' : bool((result[7] >> 4) & 1), 'ResetControlOnTimeout' : bool((result[7] >> 5) & 1), 'ResetCommOnTimeout' : bool((result[7] >> 6) & 1), 'TimeoutPeriod' : struct.unpack('<H', struct.pack("BB", *result[8:10]))[0], 'DIOConfigA' : result[10], 'DIOConfigB' : result[11], 'DAC0' : struct.unpack('<H', struct.pack("BB", *result[12:14]))[0], 'DAC1' : struct.unpack('<H', struct.pack("BB", *result[14:16]))[0] }
 
     SPIModes = { 'A' : 0, 'B' : 1, 'C' : 2, 'D' : 3 }
-    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPINNum = 1, CLKPinNum = 0, MISOPinNum = 3, MOSIPinNum = 2):
+    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 1, CLKPinNum = 0, MISOPinNum = 3, MOSIPinNum = 2, CSPINNum = None):
         """
         Name: UE9.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
-                     SPIMode = 'A', SPIClockFactor = 0, CSPINNum = 1,
+                     SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 1,
                      CLKPinNum = 0, MISOPinNum = 3, MOSIPinNum = 2)
         
         Args: SPIBytes, a list of bytes to be transferred.
@@ -1302,10 +1303,15 @@ class UE9(Device):
               communication.
         
         NOTE: The return has been changed to a dictionary with
-              NumSPIBytesTransferred and SPIBytes.
+              NumSPIBytesTransferred and SPIBytes.  The keyword
+              argument CSPinNum was named CSPINNum in old versions.
         """
         if not isinstance(SPIBytes, list):
             raise LabJackException("SPIBytes MUST be a list of bytes")
+
+        if CSPINNum is not None:
+            warnings.warn("CSPINNum is deprecated, use CSPinNum instead", DeprecationWarning)
+            CSPinNum = CSPINNum
         
         numSPIBytes = len(SPIBytes)
         
@@ -1333,7 +1339,7 @@ class UE9(Device):
         
         command[7] = SPIClockFactor
         #command[8] = Reserved
-        command[9] = CSPINNum
+        command[9] = CSPinNum
         command[10] = CLKPinNum
         command[11] = MISOPinNum
         command[12] = MOSIPinNum


### PR DESCRIPTION
The `CSPINNum` keyword argument of `spi()` is not like the others:

    CSPINNum
    CLKPinNum
    MISOPinNum
    MOSIPinNum

This is unintuitive and was probably a typo.  This patch renames `CSPINNum` to `CSPinNum`.  Code using the old `CSPINNum` name will still work.