### PR TITLE
Fix a heap of Pylint warnings of an innocuous nature.

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -97,6 +97,7 @@ def errcheck(ret, func, args):
     else:
         return ret
 
+
 def _loadLinuxSo():
     """
     Attempts to load the liblabjackusb.so for Linux.
@@ -109,6 +110,7 @@ def _loadLinuxSo():
     l.LJUSB_Read.errcheck = errcheck
     return l
 
+
 def _loadMacDylib():
     """
     Attempts to load the liblabjackusb.dylib for Mac OS X.
@@ -120,6 +122,7 @@ def _loadMacDylib():
     l.LJUSB_Stream.errcheck = errcheck
     l.LJUSB_Read.errcheck = errcheck
     return l
+
 
 def _loadLibrary():
     """_loadLibrary()
@@ -203,7 +206,6 @@ class Device(object):
         self.modbusPrependZeros = True
         self.deviceLock = threading.Lock()
         self.deviceName = "LabJack"
-
 
     def _writeToLJSocketHandle(self, writeBuffer, modbus):
         # if modbus is True and self.modbusPrependZeros:
@@ -965,6 +967,7 @@ class Device(object):
 
 # --------------------- BEGIN LabJackPython ---------------------------------
 
+
 def setChecksum(command):
     """Returns a command with checksums places in the proper locations
 
@@ -1028,6 +1031,7 @@ def verifyChecksum(buffer):
         return True
 
     return False
+
 
 #  1 = LJ_ctUSB
 def listAll(deviceType, connectionType=1):
@@ -1134,11 +1138,13 @@ def listAll(deviceType, connectionType=1):
         if deviceType == 6:
             return __listAllU6Unix()
 
+
 def isHandleValid(handle):
     if _os_name == 'nt':
         return True
     else:
         return staticLib.LJUSB_IsHandleValid(handle)
+
 
 def deviceCount(devType=None):
     """Returns the number of devices connected."""
@@ -1159,6 +1165,7 @@ def deviceCount(devType=None):
         else:
             return staticLib.LJUSB_GetDevCount(devType)
 
+
 def getDevCounts():
     if _os_name == "nt":
         # Right now there is no good way to count all the U12s on a Windows box
@@ -1176,6 +1183,7 @@ def getDevCounts():
             returnDict[int(devIds[i])] = int(devCounts[i])
 
         return returnDict
+
 
 def openAllLabJacks():
     if _os_name == "nt":
@@ -1204,6 +1212,7 @@ def openAllLabJacks():
 
     return devices
 
+
 def _openLabJackUsingLJSocket(deviceType, firstFound, pAddress, LJSocket, handleOnly):
     if LJSocket is not '':
         ip, port = LJSocket.split(":")
@@ -1213,6 +1222,7 @@ def _openLabJackUsingLJSocket(deviceType, firstFound, pAddress, LJSocket, handle
         handle = LJSocketHandle('localhost', 6000, deviceType, firstFound, pAddress)
 
     return handle
+
 
 def _openLabJackUsingUDDriver(deviceType, connectionType, firstFound, pAddress, devNumber):
     if devNumber is not None:
@@ -1234,6 +1244,7 @@ def _openLabJackUsingUDDriver(deviceType, connectionType, firstFound, pAddress, 
     devHandle = handle.value
 
     return devHandle
+
 
 def _openLabJackUsingExodriver(deviceType, firstFound, pAddress, devNumber):
     devType = ctypes.c_ulong(deviceType)
@@ -1269,6 +1280,7 @@ def _openLabJackUsingExodriver(deviceType, firstFound, pAddress, devNumber):
                 device.close()
 
     raise LabJackException(LJE_LABJACK_NOT_FOUND)
+
 
 def _openUE9OverEthernet(firstFound, pAddress, devNumber):
     if firstFound is not True and pAddress is not None:
@@ -1339,6 +1351,7 @@ def _openUE9OverEthernet(firstFound, pAddress, devNumber):
     except:
         raise LabJackException("LJE_LABJACK_NOT_FOUND: Couldn't find the specified LabJack.")
 
+
 # Windows, Linux, and Mac
 def openLabJack(deviceType, connectionType, firstFound=True, pAddress=None, devNumber=None, handleOnly=False, LJSocket=None):
     """openLabJack(deviceType, connectionType, firstFound = True, pAddress = 1, LJSocket = None)
@@ -1365,6 +1378,7 @@ def openLabJack(deviceType, connectionType, firstFound=True, pAddress=None, devN
         return _makeDeviceFromHandle(handle, deviceType)
     else:
         return Device(handle, devType=deviceType)
+
 
 def _makeDeviceFromHandle(handle, deviceType):
     """ A helper function to get set all the info about a device from a handle"""
@@ -1508,6 +1522,7 @@ def _makeDeviceFromHandle(handle, deviceType):
 
     return device
 
+
 # Windows
 def AddRequest(Handle, IOType, Channel, Value, x1, UserData):
     """AddRequest(handle, ioType, channel, value, x1, userData)
@@ -1567,6 +1582,7 @@ def AddRequestS(Handle, pIOType, Channel, Value, x1, UserData):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
+
 # Windows
 def AddRequestSS(Handle, pIOType, pChannel, Value, x1, UserData):
     """Add a request to the LabJackUD request stack
@@ -1610,6 +1626,7 @@ def AddRequestSS(Handle, pIOType, pChannel, Value, x1, UserData):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
+
 # Windows
 def Go():
     """Complete all requests currently on the LabJackUD request stack
@@ -1637,6 +1654,7 @@ def Go():
         if ec != 0: raise LabJackException(ec)
     else:
         raise LabJackException("Function only supported for Windows")
+
 
 # Windows
 def GoOne(Handle):
@@ -1667,6 +1685,7 @@ def GoOne(Handle):
         if ec != 0: raise LabJackException(ec)
     else:
         raise LabJackException(0, "Function only supported for Windows")
+
 
 # Windows
 def eGet(Handle, IOType, Channel, pValue, x1):
@@ -1806,6 +1825,7 @@ def eGetRaw(Handle, IOType, Channel, pValue, x1):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
+
 # Windows
 def eGetS(Handle, pIOType, Channel, pValue, x1):
     """Perform one call to the LabJack Device
@@ -1844,6 +1864,7 @@ def eGetS(Handle, pIOType, Channel, pValue, x1):
         return pv.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
+
 
 # Windows
 def eGetSS(Handle, pIOType, pChannel, pValue, x1):
@@ -1894,6 +1915,7 @@ def eGetRawS(Handle, pIOType, Channel, pValue, x1):
     """
     pass
 
+
 # Windows
 def ePut(Handle, IOType, Channel, Value, x1):
     """Put one value to the LabJack device
@@ -1935,6 +1957,7 @@ def ePut(Handle, IOType, Channel, Value, x1):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
+    
 # Windows
 def ePutS(Handle, pIOType, Channel, Value, x1):
     """Put one value to the LabJack device
@@ -1976,6 +1999,7 @@ def ePutS(Handle, pIOType, Channel, Value, x1):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
+    
 # Windows
 def ePutSS(Handle, pIOType, pChannel, Value, x1):
     """Put one value to the LabJack device
@@ -2017,6 +2041,7 @@ def ePutSS(Handle, pIOType, pChannel, Value, x1):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
+
 # Windows
 def GetResult(Handle, IOType, Channel):
     """Put one value to the LabJack device
@@ -2055,6 +2080,7 @@ def GetResult(Handle, IOType, Channel):
         return pv.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
+
 
 # Windows
 def GetResultS(Handle, pIOType, Channel):
@@ -2095,6 +2121,7 @@ def GetResultS(Handle, pIOType, Channel):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
+
 # Windows
 def GetResultSS(Handle, pIOType, pChannel):
     """Put one value to the LabJack device
@@ -2133,6 +2160,7 @@ def GetResultSS(Handle, pIOType, pChannel):
         return pv.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
+
 
 # Windows
 def GetFirstResult(Handle):
@@ -2181,6 +2209,7 @@ def GetFirstResult(Handle):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
+
 # Windows
 def GetNextResult(Handle):
     """List All LabJack devices of a specific type over a specific connection type.
@@ -2228,6 +2257,7 @@ def GetNextResult(Handle):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
+
 # Windows
 def DoubleToStringAddress(number):
     """Converts a number (base 10) to an IP string.
@@ -2250,6 +2280,7 @@ def DoubleToStringAddress(number):
     number = int(number)
     address = "%i.%i.%i.%i" % ((number >> 8 * 3 & 0xFF), (number >> 8 * 2 & 0xFF), (number >> 8 & 0xFF), (number & 0xFF))
     return address
+
 
 def StringToDoubleAddress(pString):
     """Converts an IP string to a number (base 10).
@@ -2278,6 +2309,7 @@ def StringToDoubleAddress(pString):
         raise LabJackException(0, "IP address not correctly formatted")
 
     return value
+
 
 # Windows
 def StringToConstant(pString):
@@ -2371,6 +2403,7 @@ ERROR_TO_STRING_DICT['114'] = ("UART_NOT_ENABLED", "")
 ERROR_TO_STRING_DICT['115'] = ("UART_RXOVERFLOW", "")
 ERROR_TO_STRING_DICT['116'] = ("I2C_BUS_BUSY", "")
 
+
 def lowlevelErrorToString(errorcode):
     """Converts a low-level errorcode into a string.
     """
@@ -2386,6 +2419,7 @@ def lowlevelErrorToString(errorcode):
         msg = "%s (%s)" % (name, errorcode)
 
     return msg
+
 
 # Windows
 def ErrorToString(ErrorCode):
@@ -2410,6 +2444,7 @@ def ErrorToString(ErrorCode):
         return pString.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
+
 
 # Windows, Linux, and Mac
 def GetDriverVersion():
@@ -2438,6 +2473,7 @@ def GetDriverVersion():
     elif _os_name == 'posix':
         staticLib.LJUSB_GetLibraryVersion.restype = ctypes.c_float
         return "%.2f" % staticLib.LJUSB_GetLibraryVersion()
+
 
 # Windows
 def TCVoltsToTemp(TCType, TCVolts, CJTempK):
@@ -2492,6 +2528,7 @@ def Close():
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
+
 # Windows, Linux and Mac
 def DriverPresent():
     try:
@@ -2516,6 +2553,7 @@ def DriverPresent():
                 except:
                     return False
     return False
+
 
 # Currently Windows only
 def U12DriverPresent():
@@ -2563,6 +2601,7 @@ def LJHash(hashStr, size):
         retBuff += outBuff[i]
 
     return retBuff
+
 
 def __listAllUE9Unix(connectionType):
     """Private listAll function for use on unix and mac machines to find UE9s.
@@ -2671,6 +2710,7 @@ def __listAllU6Unix():
             pass
 
     return deviceList
+
 
 def setChecksum16(buffer):
     total = 0
@@ -2832,6 +2872,7 @@ class UE9TCPHandle(object):
             e = sys.exc_info()[1]
             print("UE9 Handle close exception: %s" % e)
 
+
 def toDouble(bytes):
     """
     Name: toDouble(buffer)
@@ -2841,6 +2882,7 @@ def toDouble(bytes):
     right, left = unpack("<Ii", pack("B" * 8, *bytes[0:8]))
 
     return float(left) + float(right) / (2 ** 32)
+
 
 def hexWithoutQuotes(l):
     """
@@ -2852,6 +2894,7 @@ def hexWithoutQuotes(l):
 
     """
     return str([hex(i) for i in l]).replace("'", "")
+
 
 def toList(buffer):
     """
@@ -2868,6 +2911,7 @@ def toList(buffer):
         return [ord(ch) for ch in buffer]
     else:
         return [int(val) for val in buffer]
+
 
 def streamByteToInt(byte):
     """

--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -674,7 +674,8 @@ class Device(object):
         if _os_name == 'nt':
             ec = staticLib.ResetLabJack(self.handle)
 
-            if ec != 0: raise LabJackException(ec)
+            if ec != 0:
+                raise LabJackException(ec)
         elif _os_name == 'posix':
             sndDataBuff = [0] * 4
 
@@ -1534,7 +1535,8 @@ def AddRequest(Handle, IOType, Channel, Value, x1, UserData):
         ud = ctypes.c_double(UserData)
 
         ec = staticLib.AddRequest(Handle, IOType, Channel, v, x1, ud)
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
@@ -1578,7 +1580,8 @@ def AddRequestS(Handle, pIOType, Channel, Value, x1, UserData):
 
         ec = staticLib.AddRequestS(Handle, pIOType, Channel, v, x1, ud)
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
@@ -1622,7 +1625,8 @@ def AddRequestSS(Handle, pIOType, pChannel, Value, x1, UserData):
 
         ec = staticLib.AddRequestSS(Handle, pIOType, pChannel, v, x1, ud)
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
@@ -1651,7 +1655,8 @@ def Go():
     if _os_name == 'nt':
         ec = staticLib.Go()
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
     else:
         raise LabJackException("Function only supported for Windows")
 
@@ -1682,7 +1687,8 @@ def GoOne(Handle):
     if _os_name == 'nt':
         ec = staticLib.GoOne(Handle)
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
@@ -1724,7 +1730,8 @@ def eGet(Handle, IOType, Channel, pValue, x1):
         # staticLib.eGet.argtypes = [ctypes.c_long, ctypes.c_long, ctypes.c_long, ctypes.c_double, ctypes.c_long]
         # ec = staticLib.eGet(Handle, IOType, Channel, pValue, x1)
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
         # print("EGet:" + str(ppv))
         # print("Other:" + str(ppv.contents))
         return pv.value
@@ -1820,7 +1827,8 @@ def eGetRaw(Handle, IOType, Channel, pValue, x1):
                     if x1Type == "int":
                         x1[i] = x1[i] & 0xff
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
         return pv.value, x1
     else:
         raise LabJackException(0, "Function only supported for Windows")
@@ -1860,7 +1868,8 @@ def eGetS(Handle, pIOType, Channel, pValue, x1):
         pv = ctypes.c_double(pValue)
         ec = staticLib.eGetS(Handle, pIOType, Channel, ctypes.byref(pv), x1)
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
         return pv.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
@@ -1900,7 +1909,8 @@ def eGetSS(Handle, pIOType, pChannel, pValue, x1):
         pv = ctypes.c_double(pValue)
         ec = staticLib.eGetSS(Handle, pIOType, pChannel, ctypes.byref(pv), x1)
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
         return pv.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
@@ -1953,7 +1963,8 @@ def ePut(Handle, IOType, Channel, Value, x1):
         pv = ctypes.c_double(Value)
         ec = staticLib.ePut(Handle, IOType, Channel, pv, x1)
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
@@ -1995,7 +2006,8 @@ def ePutS(Handle, pIOType, Channel, Value, x1):
         pv = ctypes.c_double(Value)
         ec = staticLib.ePutS(Handle, pIOType, Channel, pv, x1)
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
@@ -2037,7 +2049,8 @@ def ePutSS(Handle, pIOType, pChannel, Value, x1):
         pv = ctypes.c_double(Value)
         ec = staticLib.ePutSS(Handle, pIOType, pChannel, pv, x1)
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
@@ -2076,7 +2089,8 @@ def GetResult(Handle, IOType, Channel):
         pv = ctypes.c_double()
         ec = staticLib.GetResult(Handle, IOType, Channel, ctypes.byref(pv))
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
         return pv.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
@@ -2116,7 +2130,8 @@ def GetResultS(Handle, pIOType, Channel):
         pv = ctypes.c_double()
         ec = staticLib.GetResultS(Handle, pIOType, Channel, ctypes.byref(pv))
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
         return pv.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
@@ -2156,7 +2171,8 @@ def GetResultSS(Handle, pIOType, pChannel):
         pv = ctypes.c_double()
         ec = staticLib.GetResultSS(Handle, pIOType, pChannel, ctypes.byref(pv))
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
         return pv.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
@@ -2204,7 +2220,8 @@ def GetFirstResult(Handle):
                                       ctypes.byref(pchan), ctypes.byref(pv),
                                       ctypes.byref(px), ctypes.byref(pud))
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
         return pio.value, pchan.value, pv.value, px.value, pud.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
@@ -2252,7 +2269,8 @@ def GetNextResult(Handle):
                                      ctypes.byref(pchan), ctypes.byref(pv),
                                      ctypes.byref(px), ctypes.byref(pud))
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
         return pio.value, pchan.value, pv.value, px.value, pud.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
@@ -2504,7 +2522,8 @@ def TCVoltsToTemp(TCType, TCVolts, CJTempK):
         ec = staticLib.TCVoltsToTemp(ctypes.c_long(TCType), ctypes.c_double(TCVolts),
                                      ctypes.c_double(CJTempK), ctypes.byref(pTCTempK))
 
-        if ec != 0: raise LabJackException(ec)
+        if ec != 0:
+            raise LabJackException(ec)
         return pTCTempK.value
     else:
         raise LabJackException(0, "Function only supported for Windows")
@@ -2595,7 +2614,8 @@ def LJHash(hashStr, size):
                           size,
                           ctypes.cast(outBuff, ctypes.POINTER(ctypes.c_char)),
                           0)
-    if ec != 0: raise LabJackException(ec)
+    if ec != 0:
+        raise LabJackException(ec)
 
     for i in range(16):
         retBuff += outBuff[i]

--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -52,6 +52,7 @@ class LabJackException(Exception):
     If errorString is not specified then errorString is set by errorCode.
     """
     def __init__(self, ec=0, errorString=''):
+        Exception.__init__(self)
         self.errorCode = ec
         self.errorString = errorString
 
@@ -75,6 +76,7 @@ class LowlevelErrorException(LabJackException):
 class NullHandleException(LabJackException):
     """Raised when the return value of OpenDevice is null."""
     def __init__(self):
+        LabJackException.__init__(self)
         self.errorString = "Couldn't open device. Please check that the device you are trying to open is connected."
 
 
@@ -137,7 +139,6 @@ def _loadLibrary():
             wlib = ctypes.CDLL("labjackud")
         if wlib is not None:
             try:
-                wlib.eGetPtr
                 #eGetPtr is available in the UD driver version installed.
                 _use_ptr = True
             except:
@@ -2677,7 +2678,7 @@ def __listAllU6Unix():
     return deviceList
 
 def setChecksum16(buffer):
-    total = 0;
+    total = 0
 
     for i in range(6, len(buffer)):
         total += (buffer[i] & 0xff)
@@ -2722,7 +2723,7 @@ class LJSocketHandle(object):
             if status.lower().startswith('ok'):
                 lines = []
                 marked = None
-                for i in range(int(numLines)):
+                for _ in range(int(numLines)):
                     l = f.readline().strip()
                     dev = parseline(l)
 
@@ -2835,7 +2836,6 @@ class UE9TCPHandle(object):
         except Exception:
             e = sys.exc_info()[1]
             print("UE9 Handle close exception: %s" % e)
-            pass
 
 def toDouble(bytes):
     """

--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -35,8 +35,9 @@ NUMBER_OF_UNIQUE_LABJACK_PRODUCT_IDS = 4
 
 _os_name = ""  # Set to "nt" or "posix" in _loadLibrary.
 
-_use_ptr = True  # Set to True or False in _loadLibrary. Indicates whether to use
-                 # the Ptr version of certain UD calls or not. Windows only.
+_use_ptr = True  # Set to True or False in _loadLibrary. Indicates
+                 # whether to use the Ptr version of certain UD calls
+                 # or not. Windows only.
 
 _use_py2 = sys.version_info < (3, 0)  # Indicates to use Python 2.x or
                                       # Python 3+ when needed.
@@ -552,7 +553,6 @@ class Device(object):
 
             return result
 
-
     def ping(self):
         try:
             if self.devType == LJ_dtUE9:
@@ -577,7 +577,6 @@ class Device(object):
             e = sys.exc_info()[1]
             print(e)
             return False
-
 
     def open(self, devType, Ethernet=False, firstFound=True, serial=None, localId=None, devNumber=None, ipAddress=None, handleOnly=False, LJSocket=None):
         """
@@ -619,7 +618,6 @@ class Device(object):
             self._loadChangedIntoSelf(d)
 
         self._registerAtExitClose()
-
 
     def _loadChangedIntoSelf(self, d):
         for key, value in d.changed.items():
@@ -929,6 +927,7 @@ class Device(object):
         return self.setDefaults(SetToFactoryDefaults=True)
 
     validDefaultBlocks = range(8)
+
     def readDefaults(self, BlockNum, ReadCurrent=False):
         """
         Name: Device.readDefaults(BlockNum)
@@ -1014,7 +1013,6 @@ def setChecksum(command):
     except Exception:
         e = sys.exc_info()[1]
         raise LabJackException("SetChecksum Exception:" + str(e))
-
 
 
 def verifyChecksum(buffer):
@@ -1968,7 +1966,7 @@ def ePut(Handle, IOType, Channel, Value, x1):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
-    
+
 # Windows
 def ePutS(Handle, pIOType, Channel, Value, x1):
     """Put one value to the LabJack device
@@ -2011,7 +2009,7 @@ def ePutS(Handle, pIOType, Channel, Value, x1):
     else:
         raise LabJackException(0, "Function only supported for Windows")
 
-    
+
 # Windows
 def ePutSS(Handle, pIOType, pChannel, Value, x1):
     """Put one value to the LabJack device
@@ -2685,7 +2683,7 @@ def __listAllUE9Unix(connectionType):
                         # Local ID
                         localId = rcvDataBuff[8] & 0xff
 
-                        deviceList[serial] = dict(devType=LJ_dtUE9, localId=localId, \
+                        deviceList[serial] = dict(devType=LJ_dtUE9, localId=localId,
                                                   serialNumber=serial, ipAddress=ipAddress)
                 except Exception:
                     pass
@@ -2693,7 +2691,6 @@ def __listAllUE9Unix(connectionType):
             pass
 
     return deviceList
-
 
 
 def __listAllU3Unix():
@@ -2710,7 +2707,6 @@ def __listAllU3Unix():
             deviceList[str(device.serialNumber)] = device.__dict__
         except LabJackException:
             pass
-
 
     return deviceList
 
@@ -2973,8 +2969,9 @@ LJ_ctLJSOCKET = 200  # Connection type for USB LabJack connected to LJSocket ser
 
 # io types:
 LJ_ioGET_AIN = 10  # UE9 + U3 + U6.  This is single ended version.
-LJ_ioGET_AIN_DIFF = 15  # U3 + U6.  Put second channel in x1.  For U3, if 32 is
-                        # passed as x1, Vref will be added to the result.
+LJ_ioGET_AIN_DIFF = 15  # U3 + U6.  Put second channel in x1.  For U3,
+                        # if 32 is passed as x1, Vref will be added to
+                        # the result.
 
 LJ_ioPUT_AIN_RANGE = 2000  # UE9 + U6
 LJ_ioGET_AIN_RANGE = 2001  # UE9 + U6
@@ -3170,8 +3167,8 @@ LJ_chLED_STATE = 17  # U3  value = LED state
 
 LJ_chSDA_SCL = 18  # U3  enable / disable SDA/SCL as digital I/O
 
-LJ_chU3HV = 22  # U3 (Read Only) Value will be 1 for a U3-HV and 0 for a U3-LV
-                # or a U3 with hardware version < 1.30
+LJ_chU3HV = 22  # U3 (Read Only) Value will be 1 for a U3-HV and 0 for
+                # a U3-LV or a U3 with hardware version < 1.30
 
 # U6 only:
 LJ_chU6_PRO = 23
@@ -3305,32 +3302,32 @@ LJ_ttT = 6008
 
 # other constants:
 # ranges (not all are supported by all devices):
-LJ_rgBIP20V = 1   # -20V to +20V
-LJ_rgBIP10V = 2   # -10V to +10V
-LJ_rgBIP5V = 3    # -5V to +5V
-LJ_rgBIP4V = 4    # -4V to +4V
-LJ_rgBIP2P5V = 5  # -2.5V to +2.5V
-LJ_rgBIP2V = 6    # -2V to +2V
-LJ_rgBIP1P25V = 7 # -1.25V to +1.25V
-LJ_rgBIP1V = 8    # -1V to +1V
-LJ_rgBIPP625V = 9 # -0.625V to +0.625V
-LJ_rgBIPP1V = 10  # -0.1V to +0.1V
-LJ_rgBIPP01V = 11 # -0.01V to +0.01V
+LJ_rgBIP20V = 1    # -20V to +20V
+LJ_rgBIP10V = 2    # -10V to +10V
+LJ_rgBIP5V = 3     # -5V to +5V
+LJ_rgBIP4V = 4     # -4V to +4V
+LJ_rgBIP2P5V = 5   # -2.5V to +2.5V
+LJ_rgBIP2V = 6     # -2V to +2V
+LJ_rgBIP1P25V = 7  # -1.25V to +1.25V
+LJ_rgBIP1V = 8     # -1V to +1V
+LJ_rgBIPP625V = 9  # -0.625V to +0.625V
+LJ_rgBIPP1V = 10   # -0.1V to +0.1V
+LJ_rgBIPP01V = 11  # -0.01V to +0.01V
 
-LJ_rgUNI20V = 101    # 0V to +20V
-LJ_rgUNI10V = 102    # 0V to +10V
-LJ_rgUNI5V = 103     # 0V to +5V
-LJ_rgUNI4V = 104     # 0V to +4V
-LJ_rgUNI2P5V = 105   # 0V to +2.5V
-LJ_rgUNI2V = 106     # 0V to +2V
-LJ_rgUNI1P25V = 107  # 0V to +1.25V
-LJ_rgUNI1V = 108     # 0V to +1V
-LJ_rgUNIP625V = 109  # 0V to +0.625V
-LJ_rgUNIP25V = 112   # 0V to +0.25V
-LJ_rgUNIP500V = 110  # 0V to +0.500V
-LJ_rgUNIP3125V = 111 # 0V to +0.3125V
-LJ_rgUNIP025V = 113  # 0V to +0.025V
-LJ_rgUNIP0025V = 114 # 0V to +0.0025V
+LJ_rgUNI20V = 101     # 0V to +20V
+LJ_rgUNI10V = 102     # 0V to +10V
+LJ_rgUNI5V = 103      # 0V to +5V
+LJ_rgUNI4V = 104      # 0V to +4V
+LJ_rgUNI2P5V = 105    # 0V to +2.5V
+LJ_rgUNI2V = 106      # 0V to +2V
+LJ_rgUNI1P25V = 107   # 0V to +1.25V
+LJ_rgUNI1V = 108      # 0V to +1V
+LJ_rgUNIP625V = 109   # 0V to +0.625V
+LJ_rgUNIP25V = 112    # 0V to +0.25V
+LJ_rgUNIP500V = 110   # 0V to +0.500V
+LJ_rgUNIP3125V = 111  # 0V to +0.3125V
+LJ_rgUNIP025V = 113   # 0V to +0.025V
+LJ_rgUNIP0025V = 114  # 0V to +0.0025V
 
 # timer modes:
 LJ_tmPWM16 = 0  # 16 bit PWM
@@ -3371,11 +3368,14 @@ LJ_tc48MHZ_DIV = 26   # U3: Hardware Version 1.21 or higher
 # stream wait modes
 LJ_swNONE = 1  # no wait, return whatever is available
 LJ_swALL_OR_NONE = 2  # no wait, but if all points requested aren't available, return none.
-LJ_swPUMP = 11  # wait and pump the message pump.  Prefered when called from primary thread (if you don't know
-               # if you are in the primary thread of your app then you probably are.  Do not use in worker
-               # secondary threads (i.e. ones without a message pump).
-LJ_swSLEEP = 12  # wait by sleeping (don't do this in the primary thread of your app, or it will temporarily
-                # hang)    This is usually used in worker secondary threads.
+LJ_swPUMP = 11  # wait and pump the message pump.  Prefered when
+                # called from primary thread (if you don't know if you
+                # are in the primary thread of your app then you
+                # probably are.  Do not use in worker secondary
+                # threads (i.e. ones without a message pump).
+LJ_swSLEEP = 12  # wait by sleeping (don't do this in the primary
+                 # thread of your app, or it will temporarily hang)
+                 # This is usually used in worker secondary threads.
 
 
 # BETA CONSTANTS

--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -138,12 +138,7 @@ def _loadLibrary():
             #Cygwin detected. WinDLL not available, but CDLL seems to work.
             wlib = ctypes.CDLL("labjackud")
         if wlib is not None:
-            try:
-                #eGetPtr is available in the UD driver version installed.
-                _use_ptr = True
-            except:
-                #eGetPtr is not available in the UD driver version installed.
-                _use_ptr = False
+            _use_ptr = hasattr(wlib, 'eGetPtr')
             return wlib
     except Exception:
         e = sys.exc_info()[1]

--- a/src/Modbus.py
+++ b/src/Modbus.py
@@ -194,12 +194,7 @@ def writeRegisterRequestValue(data):
     return packet[0]
 
 class ModbusException(Exception):
-
-    def __init__(self, exceptCode):
-        self.exceptCode = exceptCode
-
-    def __str__(self):
-        return repr(self.exceptCode)
+    pass
 
 def calcNumberOfRegisters(addr, numReg = None):
     return calcNumberOfRegistersAndFormat(addr, numReg)[0]

--- a/src/Modbus.py
+++ b/src/Modbus.py
@@ -30,6 +30,7 @@ GLOBAL_TRANSACTION_ID_LOCK = threading.Lock()
 
 MAX_TRANS_ID = 64760
 
+
 def _calcBaseTransId():
     t = datetime.datetime.now()
     d = "%s%s%s%s" % (t.hour, t.minute, t.second, t.microsecond)
@@ -38,6 +39,7 @@ def _calcBaseTransId():
 
 BASE_TRANS_ID = _calcBaseTransId()
 CURRENT_TRANS_IDS = set()
+
 
 def _buildHeaderBytes(length=6, unitId=None):
     with GLOBAL_TRANSACTION_ID_LOCK:
@@ -53,6 +55,7 @@ def _buildHeaderBytes(length=6, unitId=None):
 
         return pack('>HHHB', *basicHeader)
 
+
 def _checkTransId(transId):
     with GLOBAL_TRANSACTION_ID_LOCK:
         global CURRENT_TRANS_IDS
@@ -62,6 +65,7 @@ def _checkTransId(transId):
         else:
             raise ModbusException("Got an unexpected transaction ID. Id = %s, Set = %s" % (transId, CURRENT_TRANS_IDS))
 
+
 def readHoldingRegistersRequest(addr, numReg=None, unitId=None):
     if numReg is None:
         numReg = calcNumberOfRegisters(addr)
@@ -69,6 +73,7 @@ def readHoldingRegistersRequest(addr, numReg=None, unitId=None):
     packet = _buildHeaderBytes(unitId=unitId) + pack('>BHH', 0x03, addr, numReg)
 
     return packet
+
 
 def readHoldingRegistersResponse(packet, payloadFormat=None):
     # Example: Device type is 9
@@ -117,12 +122,14 @@ def readHoldingRegistersResponse(packet, payloadFormat=None):
     else:
         return list(payload)
 
+
 def readInputRegistersRequest(addr, numReg=None):
     if numReg is None:
         numReg = calcNumberOfRegisters(addr)
 
     packet = _buildHeaderBytes() + pack('>BHH', 0x04, addr, numReg)
     return packet
+
 
 def readInputRegistersResponse(packet, payloadFormat=None):
     # Example: Device type is 9
@@ -162,6 +169,7 @@ def readInputRegistersResponse(packet, payloadFormat=None):
 
     return payload
 
+
 def writeRegisterRequest(addr, value, unitId=None):
     if not isinstance(value, int):
         raise TypeError("Value written must be an integer.")
@@ -169,6 +177,7 @@ def writeRegisterRequest(addr, value, unitId=None):
     packet = _buildHeaderBytes(unitId=unitId) + pack('>BHH', 0x06, addr, value)
 
     return packet
+
 
 def writeRegistersRequest(startAddr, values, unitId=None):
     numReg = len(values)
@@ -188,19 +197,24 @@ def writeRegistersRequest(startAddr, values, unitId=None):
     packet = header + pack(format, *values)
     return packet
 
+
 def writeRegisterRequestValue(data):
     """Return the value to be written in a writeRegisterRequest Packet."""
     packet = unpack('>H', data[10:])
     return packet[0]
 
+
 class ModbusException(Exception):
     pass
+
 
 def calcNumberOfRegisters(addr, numReg=None):
     return calcNumberOfRegistersAndFormat(addr, numReg)[0]
 
+
 def calcFormat(addr, numReg=None):
     return calcNumberOfRegistersAndFormat(addr, numReg)[1]
+
 
 def calcNumberOfRegistersAndFormat(addr, numReg=None):
     # TODO add special cases for channels above
@@ -260,13 +274,16 @@ def calcNumberOfRegistersAndFormat(addr, numReg=None):
     else:
         return (minNumReg, '>' + format)
 
+
 def getStartingAddress(packet):
     """Get the address of a modbus request"""
     return ((ord(packet[8]) << 8) + ord(packet[9]))
 
+
 def getRequestType(packet):
     """Get the request type of a modbus request."""
     return ord(packet[7])
+
 
 def getTransactionId(packet):
     """Pulls out the transaction id of the packet"""
@@ -275,12 +292,14 @@ def getTransactionId(packet):
     else:
         return unpack(">H", packet[:2])[0]
 
+
 def getProtocolId(packet):
     """Pulls out the transaction id of the packet"""
     if isinstance(packet, list):
         return unpack(">H", pack("BB", *packet[2:4]))[0]
     else:
         return unpack(">H", packet[2:4])[0]
+
 
 def parseIntoPackets(packet):
     while True:
@@ -295,6 +314,7 @@ def parseIntoPackets(packet):
         else:
             yield packet[:firstLength]
             packet = packet[firstLength:]
+
 
 def parseSpontaneousDataPacket(packet):
     if isinstance(packet, list):

--- a/src/u12.py
+++ b/src/u12.py
@@ -56,6 +56,7 @@ class U12Exception(Exception):
     """
     pass
 
+
 class BitField(object):
     """
     Provides a method for working with bit fields.
@@ -336,6 +337,7 @@ class BitField(object):
         """
         return other + self.asByte()
 
+
 def errcheck(ret, func, args):
     if ret == -1:
         try:
@@ -346,6 +348,7 @@ def errcheck(ret, func, args):
     else:
         return ret
 
+
 def _loadLinuxSo():
     try:
         l = ctypes.CDLL("liblabjackusb.so", use_errno=True)
@@ -355,6 +358,7 @@ def _loadLinuxSo():
     l.LJUSB_Read.errcheck = errcheck
     return l
 
+
 def _loadMacDylib():
     try:
         l = ctypes.CDLL("liblabjackusb.dylib", use_errno=True)
@@ -363,6 +367,7 @@ def _loadMacDylib():
     l.LJUSB_Stream.errcheck = errcheck
     l.LJUSB_Read.errcheck = errcheck
     return l
+
 
 def _loadLibrary():
     """_loadLibrary()
@@ -518,7 +523,6 @@ class U12(object):
             else:
                 raise Exception("Invalid combination of parameters.")
 
-
             if not self._autoCloseSetup:
                 # Only need to register auto-close once per device.
                 atexit.register(self.close)
@@ -603,7 +607,6 @@ class U12(object):
         """
         results = self.rawReadRAM(0x08)
         return results['DataByte0']
-
 
     # Begin Section 5 Functions
 
@@ -1179,7 +1182,6 @@ class U12(object):
         for _ in range(NumScans):
             resultsList.append(self.read())
 
-
         returnDict = {}
 
         returnDict['BufferOverflowOrChecksumErrors'] = list()
@@ -1230,7 +1232,6 @@ class U12(object):
         return returnDict
 
 
-
     def rawAIContinuous(self, channel0PGAMUX=8, channel1PGAMUX=9, channel2PGAMUX=10, channel3PGAMUX=11, FeatureReports=False, CounterRead=False, UpdateIO=False, LEDState=True, IO3ToIO0States=0, SampleInterval=15000):
         """
         Currently in development.
@@ -1277,7 +1278,6 @@ class U12(object):
             returnDict['Byte0'] = byte0bf
             returnDict['IterationCounter'] = (results[1] >> 5)
             returnDict['Backlog'] = results[1] & 0xf
-
 
             yield returnDict
 
@@ -2947,12 +2947,14 @@ class U12(object):
 
         return retBuff
 
+
 def isIterable(var):
     try:
         iter(var)
         return True
     except:
         return False
+
 
 def listToCArray(list, dataType):
     arrayType = dataType * len(list)
@@ -2962,12 +2964,14 @@ def listToCArray(list, dataType):
 
     return array
 
+
 def cArrayToList(array):
     list = []
     for item in array:
         list.append(item)
 
     return list
+
 
 def getErrorString(errorcode):
     """
@@ -2982,6 +2986,7 @@ def getErrorString(errorcode):
     errorString = ctypes.c_char_p(" " * 50)
     staticLib.GetErrorString(errorcode, errorString)
     return errorString.value
+
 
 def hexWithoutQuotes(l):
     """ Return a string listing hex without all the single quotes.

--- a/src/u12.py
+++ b/src/u12.py
@@ -1935,7 +1935,8 @@ class U12(object):
 
             ecode = staticLib.EAnalogIn(ctypes.byref(ljid), demo, channel, gain, ctypes.byref(ad0), ctypes.byref(ad1))
 
-            if ecode != 0: raise U12Exception(ecode)
+            if ecode != 0:
+                raise U12Exception(ecode)
 
             return {"idnum": ljid.value, "overVoltage": ad0.value, "voltage": ad1.value}
         else:
@@ -1966,7 +1967,8 @@ class U12(object):
             ljid = ctypes.c_long(idNum)
             ecode = staticLib.EAnalogOut(ctypes.byref(ljid), demo, ctypes.c_float(analogOut0), ctypes.c_float(analogOut1))
 
-            if ecode != 0: raise U12Exception(ecode)
+            if ecode != 0:
+                raise U12Exception(ecode)
 
             return {"idnum": ljid.value}
         else:
@@ -2006,7 +2008,8 @@ class U12(object):
 
             ecode = staticLib.ECount(ctypes.byref(ljid), demo, resetCounter, ctypes.byref(count), ctypes.byref(ms))
 
-            if ecode != 0: raise U12Exception(ecode)
+            if ecode != 0:
+                raise U12Exception(ecode)
 
             return {"idnum": ljid.value, "count": count.value, "ms": ms.value}
         else:
@@ -2039,7 +2042,8 @@ class U12(object):
 
             ecode = staticLib.EDigitalIn(ctypes.byref(ljid), demo, channel, readD, ctypes.byref(state))
 
-            if ecode != 0: raise U12Exception(ecode)
+            if ecode != 0:
+                raise U12Exception(ecode)
 
             return {"idnum": ljid.value, "state": state.value}
         else:
@@ -2090,7 +2094,8 @@ class U12(object):
 
             ecode = staticLib.EDigitalOut(ctypes.byref(ljid), demo, channel, writeD, state)
 
-            if ecode != 0: raise U12Exception(ecode)
+            if ecode != 0:
+                raise U12Exception(ecode)
 
             return {"idnum": ljid.value}
         else:
@@ -2141,10 +2146,14 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         # Check to make sure that everything is checked
-        if not isIterable(channels): raise TypeError("channels must be iterable")
-        if not isIterable(gains): raise TypeError("gains must be iterable")
-        if len(channels) < numChannels: raise ValueError("channels must have atleast numChannels elements")
-        if len(gains) < numChannels: raise ValueError("gains must have atleast numChannels elements")
+        if not isIterable(channels):
+            raise TypeError("channels must be iterable")
+        if not isIterable(gains):
+            raise TypeError("gains must be iterable")
+        if len(channels) < numChannels:
+            raise ValueError("channels must have atleast numChannels elements")
+        if len(gains) < numChannels:
+            raise ValueError("gains must have atleast numChannels elements")
 
         # Convert lists to arrays and create other ctypes
         channelsArray = listToCArray(channels, ctypes.c_long)
@@ -2156,7 +2165,8 @@ class U12(object):
 
         ecode = staticLib.AISample(ctypes.byref(idNum), demo, ctypes.byref(stateIOin), updateIO, ledOn, numChannels, ctypes.byref(channelsArray), ctypes.byref(gainsArray), disableCal, ctypes.byref(overVoltage), ctypes.byref(voltages))
 
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value, "stateIO": stateIOin.value, "overVoltage": overVoltage.value, "voltages": voltages[0:numChannels]}
 
@@ -2177,8 +2187,10 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         # check list sizes
-        if len(channels) < numChannels: raise ValueError("channels must have atleast numChannels elements")
-        if len(gains) < numChannels: raise ValueError("gains must have atleast numChannels elements")
+        if len(channels) < numChannels:
+            raise ValueError("channels must have atleast numChannels elements")
+        if len(gains) < numChannels:
+            raise ValueError("gains must have atleast numChannels elements")
 
         # Convert lists to arrays and create other ctypes
         channelsArray = listToCArray(channels, ctypes.c_long)
@@ -2192,7 +2204,8 @@ class U12(object):
 
         ecode = staticLib.AIBurst(ctypes.byref(idNum), demo, stateIOin, updateIO, ledOn, numChannels, ctypes.byref(channelsArray), ctypes.byref(gainsArray), ctypes.byref(scanRate), disableCal, triggerIO, triggerState, numScans, timeout, ctypes.byref(voltages), ctypes.byref(stateIOout), ctypes.byref(overVoltage), transferMode)
 
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value, "scanRate": scanRate.value, "voltages": voltages, "stateIOout": stateIOout, "overVoltage": overVoltage.value}
 
@@ -2211,8 +2224,10 @@ class U12(object):
         staticLib.AIStreamStart.restype = ctypes.c_long
 
         # check list sizes
-        if len(channels) < numChannels: raise ValueError("channels must have atleast numChannels elements")
-        if len(gains) < numChannels: raise ValueError("gains must have atleast numChannels elements")
+        if len(channels) < numChannels:
+            raise ValueError("channels must have atleast numChannels elements")
+        if len(gains) < numChannels:
+            raise ValueError("gains must have atleast numChannels elements")
         # if len(stateIOin) < 4: raise ValueError("stateIOin must have atleast 4 elements")
 
         # Check id number
@@ -2227,7 +2242,8 @@ class U12(object):
 
         ecode = staticLib.AIStreamStart(ctypes.byref(idNum), demo, stateIOin, updateIO, ledOn, numChannels, ctypes.byref(channelsArray), ctypes.byref(gainsArray), ctypes.byref(scanRate), disableCal, 0, readCount)
 
-        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
+        if ecode != 0:
+            raise U12Exception(ecode)  # TODO: Switch this out for exception
 
         # The ID number must be saved for AIStream
         self.id = idNum.value
@@ -2267,7 +2283,8 @@ class U12(object):
 
         ecode = staticLib.AIStreamRead(localID, numScans, timeout, ctypes.byref(voltages), ctypes.byref(stateIOout), ctypes.byref(reserved), ctypes.byref(ljScanBacklog), ctypes.byref(overVoltage))
 
-        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
+        if ecode != 0:
+            raise U12Exception(ecode)  # TODO: Switch this out for exception
 
         return {"voltages": voltages, "stateIOout": stateIOout, "reserved": reserved.value, "ljScanBacklog": ljScanBacklog.value, "overVoltage": overVoltage.value}
 
@@ -2293,7 +2310,8 @@ class U12(object):
 
         ecode = staticLib.AIStreamClear(localID)
 
-        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
+        if ecode != 0:
+            raise U12Exception(ecode)  # TODO: Switch this out for exception
 
     def aoUpdate(self, idNum=None, demo=0, trisD=None, trisIO=None, stateD=None, stateIO=None, updateDigital=0, resetCounter=0, analogOut0=0, analogOut1=0):
         """
@@ -2313,22 +2331,31 @@ class U12(object):
 
         #  Check tris and state arguments
         if updateDigital > 0:
-            if trisD is None: raise ValueError("keyword argument trisD must be set")
-            if trisIO is None: raise ValueError("keyword argument trisIO must be set")
-            if stateD is None: raise ValueError("keyword argument stateD must be set")
-            if stateIO is None: raise ValueError("keyword argument stateIO must be set")
+            if trisD is None:
+                raise ValueError("keyword argument trisD must be set")
+            if trisIO is None:
+                raise ValueError("keyword argument trisIO must be set")
+            if stateD is None:
+                raise ValueError("keyword argument stateD must be set")
+            if stateIO is None:
+                raise ValueError("keyword argument stateIO must be set")
 
         # Create ctypes
-        if stateD is None: stateD = ctypes.c_long(0)
-        else: stateD = ctypes.c_long(stateD)
-        if stateIO is None: stateIO = ctypes.c_long(0)
-        else: stateIO = ctypes.c_long(stateIO)
+        if stateD is None:
+            stateD = ctypes.c_long(0)
+        else:
+            stateD = ctypes.c_long(stateD)
+        if stateIO is None:
+            stateIO = ctypes.c_long(0)
+        else:
+            stateIO = ctypes.c_long(stateIO)
         count = ctypes.c_ushort(999)
 
         # Create arrays and other ctypes
         ecode = staticLib.AOUpdate(ctypes.byref(idNum), demo, trisD, trisIO, ctypes.byref(stateD), ctypes.byref(stateIO), updateDigital, resetCounter, ctypes.byref(count), ctypes.c_float(analogOut0), ctypes.c_float(analogOut1))
 
-        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
+        if ecode != 0:
+            raise U12Exception(ecode)  # TODO: Switch this out for exception
 
         return {"idnum": idNum.value, "stateD": stateD.value, "stateIO": stateIO.value, "count": count.value}
 
@@ -2350,7 +2377,8 @@ class U12(object):
 
         ecode = staticLib.AsynchConfig(ctypes.byref(idNum), demo, timeoutMult, configA, configB, configTE, fullA, fullB, fullC, halfA, halfB, halfC)
 
-        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
+        if ecode != 0:
+            raise U12Exception(ecode)  # TODO: Switch this out for exception
 
         return {"idNum": idNum.value}
 
@@ -2372,7 +2400,8 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         # Check size of data
-        if len(data) > 18: raise ValueError("data can not be larger than 18 elements")
+        if len(data) > 18:
+            raise ValueError("data can not be larger than 18 elements")
 
         # Make data 18 elements large
         dataArray = [0] * 18
@@ -2382,7 +2411,8 @@ class U12(object):
 
         ecode = staticLib.Asynch(ctypes.byref(idNum), demo, portB, enableTE, enableTO, enableDel, baudrate, numWrite, numRead, ctypes.byref(dataArray))
 
-        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
+        if ecode != 0:
+            raise U12Exception(ecode)  # TODO: Switch this out for exception
 
         return {"idnum": long, "data": dataArray}
 
@@ -2426,7 +2456,8 @@ class U12(object):
             bits = ctypes.c_long(999)
             ecode = staticLib.VoltsToBits(chnum, chgain, ctypes.c_float(volts), ctypes.byref(bits))
 
-            if ecode != 0: raise U12Exception(ecode)
+            if ecode != 0:
+                raise U12Exception(ecode)
 
             return bits.value
         else:
@@ -2456,7 +2487,8 @@ class U12(object):
 
         ecode = staticLib.Counter(ctypes.byref(idNum), demo, ctypes.byref(stateD), ctypes.byref(stateIO), resetCounter, enableSTB, ctypes.byref(count))
 
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value, "stateD": stateD.value, "stateIO": stateIO.value, "count": count.value}
 
@@ -2478,25 +2510,37 @@ class U12(object):
 
         # Check tris and state parameters
         if updateDigital > 0:
-            if trisD is None: raise ValueError("keyword argument trisD must be set")
-            if trisIO is None: raise ValueError("keyword argument trisIO must be set")
-            if stateD is None: raise ValueError("keyword argument stateD must be set")
-            if stateIO is None: raise ValueError("keyword argument stateIO must be set")
+            if trisD is None:
+                raise ValueError("keyword argument trisD must be set")
+            if trisIO is None:
+                raise ValueError("keyword argument trisIO must be set")
+            if stateD is None:
+                raise ValueError("keyword argument stateD must be set")
+            if stateIO is None:
+                raise ValueError("keyword argument stateIO must be set")
 
         # Create ctypes
-        if trisD is None: trisD = ctypes.c_long(999)
-        else: trisD = ctypes.c_long(trisD)
-        if stateD is None: stateD = ctypes.c_long(999)
-        else: stateD = ctypes.c_long(stateD)
-        if stateIO is None: stateIO = ctypes.c_long(0)
-        else: stateIO = ctypes.c_long(stateIO)
+        if trisD is None:
+            trisD = ctypes.c_long(999)
+        else:
+            trisD = ctypes.c_long(trisD)
+        if stateD is None:
+            stateD = ctypes.c_long(999)
+        else:
+            stateD = ctypes.c_long(stateD)
+        if stateIO is None:
+            stateIO = ctypes.c_long(0)
+        else:
+            stateIO = ctypes.c_long(stateIO)
         outputD = ctypes.c_long(999)
 
         # Check trisIO
-        if trisIO is None: trisIO = 0
+        if trisIO is None:
+            trisIO = 0
 
         ecode = staticLib.DigitalIO(ctypes.byref(idNum), demo, ctypes.byref(trisD), trisIO, ctypes.byref(stateD), ctypes.byref(stateIO), updateDigital, ctypes.byref(outputD))
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value, "trisD": trisD.value, "stateD": stateD.value, "stateIO": stateIO.value, "outputD": outputD.value}
 
@@ -2525,13 +2569,15 @@ class U12(object):
         """
 
         # Check ID number
-        if idNum is None: idNum = self.id
+        if idNum is None:
+            idNum = self.id
         idNum = ctypes.c_long(idNum)
 
         staticLib.GetFirmwareVersion.restype = ctypes.c_float
         firmware = staticLib.GetFirmwareVersion(ctypes.byref(idNum))
 
-        if firmware > 512: raise U12Exception(firmware - 512)
+        if firmware > 512:
+            raise U12Exception(firmware - 512)
 
         return {"idnum": idNum.value, "firmware": firmware}
 
@@ -2556,7 +2602,8 @@ class U12(object):
 
         ecode = staticLib.GetWinVersion(ctypes.byref(majorVersion), ctypes.byref(minorVersion), ctypes.byref(buildNumber), ctypes.byref(platformID), ctypes.byref(servicePackMajor), ctypes.byref(servicePackMinor))
 
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"majorVersion": majorVersion.value, "minorVersion": minorVersion.value, "buildNumber": buildNumber.value, "platformID": platformID.value, "servicePackMajor": servicePackMajor.value, "servicePackMinor": servicePackMinor.value}
 
@@ -2583,7 +2630,8 @@ class U12(object):
         numberFound = ctypes.c_long()
 
         ecode = staticLib.ListAll(ctypes.byref(productIDList), ctypes.byref(serialnumList), ctypes.byref(localIDList), ctypes.byref(powerList), ctypes.byref(calMatrix), ctypes.byref(numberFound), ctypes.byref(reserved), ctypes.byref(reserved))
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"serialnumList": serialnumList, "localIDList": localIDList, "numberFound": numberFound.value}
 
@@ -2603,7 +2651,8 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         ecode = staticLib.LocalID(ctypes.byref(idNum), localID)
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value}
 
@@ -2623,7 +2672,8 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         ecode = staticLib.NoThread(ctypes.byref(idNum), noThread)
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value}
 
@@ -2644,7 +2694,8 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         ecode = staticLib.PulseOut(ctypes.byref(idNum), demo, lowFirst, bitSelect, numPulses, timeB1, timeC1, timeB2, timeC2)
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value}
 
@@ -2665,7 +2716,8 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         ecode = staticLib.PulseOutStart(ctypes.byref(idNum), demo, lowFirst, bitSelect, numPulses, timeB1, timeC1, timeB2, timeC2)
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value}
 
@@ -2686,7 +2738,8 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         ecode = staticLib.PulseOutFinish(ctypes.byref(idNum), demo, timeoutMS)
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value}
 
@@ -2707,7 +2760,8 @@ class U12(object):
         timeC = ctypes.c_long(0)
 
         ecode = staticLib.PulseOutCalc(ctypes.byref(frequency), ctypes.byref(timeB), ctypes.byref(timeC))
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"frequency": frequency.value, "timeB": timeB.value, "timeC": timeC.value}
 
@@ -2728,7 +2782,8 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         ecode = staticLib.ReEnum(ctypes.byref(idNum))
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value}
 
@@ -2749,7 +2804,8 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         ecode = staticLib.Reset(ctypes.byref(idNum))
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value}
 
@@ -2786,7 +2842,8 @@ class U12(object):
         rh = ctypes.c_float(0)
 
         ecode = staticLib.SHT1X(ctypes.byref(idNum), demo, softComm, mode, statusReg, ctypes.byref(tempC), ctypes.byref(tempF), ctypes.byref(rh))
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value, "tempC": tempC.value, "tempF": tempF.value, "rh": rh.value}
 
@@ -2803,14 +2860,16 @@ class U12(object):
         idNum = ctypes.c_long(idNum)
 
         # Check size of datatx
-        if len(datatx) != 4: raise ValueError("datatx must have exactly 4 elements")
+        if len(datatx) != 4:
+            raise ValueError("datatx must have exactly 4 elements")
 
         # Create ctypes
         datatx = listToCArray(datatx, ctypes.c_ubyte)
         datarx = (ctypes.c_ubyte * 4)((0) * 4)
 
         ecode = staticLib.SHTComm(ctypes.byref(idNum), softComm, waitMeas, serialReset, dataRate, numWrite, numRead, ctypes.byref(datatx), ctypes.byref(datarx))
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value, "datarx": datarx}
 
@@ -2837,7 +2896,8 @@ class U12(object):
             idNum = self.id
         idNum = ctypes.c_long(idNum)
 
-        if controlCS > 0 and csLine is None: raise ValueError("csLine must be specified")
+        if controlCS > 0 and csLine is None:
+            raise ValueError("csLine must be specified")
 
         # Make sure data is 18 elements
         cData = [0] * 18
@@ -2846,7 +2906,8 @@ class U12(object):
         cData = listToCArray(cData, ctypes.c_long)
 
         ecode = staticLib.Synch(ctypes.byref(idNum), demo, mode, msDelay, husDelay, controlCS, csLine, csState, configD, numWriteRead, ctypes.byref(cData))
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value, "data": cData}
 
@@ -2866,11 +2927,14 @@ class U12(object):
             idNum = self.id
         idNum = ctypes.c_long(idNum)
 
-        if len(activeDn) is not 3: raise ValueError("activeDn must have 3 elements")
-        if len(stateDn) is not 3: raise ValueError("stateDn must have 3 elements")
+        if len(activeDn) is not 3:
+            raise ValueError("activeDn must have 3 elements")
+        if len(stateDn) is not 3:
+            raise ValueError("stateDn must have 3 elements")
 
         ecode = staticLib.Watchdog(ctypes.byref(idNum), demo, active, timeout, reset, activeDn[0], activeDn[1], activeDn[2], stateDn[0], stateDn[1], stateDn[2])
-        if ecode != 0: raise U12Exception(ecode)
+        if ecode != 0:
+            raise U12Exception(ecode)
 
         return {"idnum": idNum.value}
 
@@ -2898,7 +2962,8 @@ class U12(object):
         ad3 = ctypes.c_ulong()
 
         ec = staticLib.ReadMem(ctypes.byref(ljid), ctypes.c_long(address), ctypes.byref(ad3), ctypes.byref(ad2), ctypes.byref(ad1), ctypes.byref(ad0))
-        if ec != 0: raise U12Exception(ec)
+        if ec != 0:
+            raise U12Exception(ec)
 
         addr = [0] * 4
         addr[0] = int(ad3.value & 0xff)
@@ -2928,7 +2993,8 @@ class U12(object):
 
         ljid = ctypes.c_ulong(idnum)
         ec = staticLib.WriteMem(ctypes.byref(ljid), int(unlocked), address, data[3] & 0xff, data[2] & 0xff, data[1] & 0xff, data[0] & 0xff)
-        if ec != 0: raise U12Exception(ec)
+        if ec != 0:
+            raise U12Exception(ec)
 
         return ljid.value
 
@@ -2940,7 +3006,8 @@ class U12(object):
                               size,
                               ctypes.cast(outBuff, ctypes.POINTER(ctypes.c_char)),
                               0)
-        if ec != 0: raise U12Exception(ec)
+        if ec != 0:
+            raise U12Exception(ec)
 
         for i in range(16):
             retBuff += outBuff[i]

--- a/src/u12.py
+++ b/src/u12.py
@@ -1176,7 +1176,7 @@ class U12(object):
         self.write(command)
 
         resultsList = []
-        for i in range(NumScans):
+        for _ in range(NumScans):
             resultsList.append(self.read())
 
 

--- a/src/u12.py
+++ b/src/u12.py
@@ -32,7 +32,7 @@ import time
 from struct import pack, unpack
 
 
-_os_name = "" #Set to "nt" or "posix" in _loadLibrary
+_os_name = ""  # Set to "nt" or "posix" in _loadLibrary
 
 
 class U12Exception(Exception):
@@ -132,7 +132,7 @@ class BitField(object):
     '0x6b'
 
     See the description of the __init__ method for setting the label parameters.    """
-    def __init__(self, rawByte = None, labelPrefix = "bit", labelList = None, zeroLabel = "0", oneLabel = "1"):
+    def __init__(self, rawByte=None, labelPrefix="bit", labelList=None, zeroLabel="0", oneLabel="1"):
         """
         Name: BitField.__init__(rawByte = None, labelPrefix = "bit",
                                 labelList = None, zeroLabel = "0",
@@ -198,8 +198,8 @@ class BitField(object):
         self.oneLabel = oneLabel
 
         self.rawValue = 0
-        self.rawBits = [ 0 ] * 8
-        self.data = [ self.zeroLabel ] * 8
+        self.rawBits = [0] * 8
+        self.data = [self.zeroLabel] * 8
 
         items = min(8, len(self.labelList))
         for i in reversed(range(items)):
@@ -226,7 +226,7 @@ class BitField(object):
 
         items = min(8, len(self.labelList))
         for i in reversed(range(items)):
-            self.rawBits.append( ((raw >> (i)) & 1) )
+            self.rawBits.append(((raw >> (i)) & 1))
             self.data.append(self.oneLabel if bool(((raw >> (i)) & 1)) else self.zeroLabel)
 
     def asByte(self):
@@ -243,7 +243,7 @@ class BitField(object):
         """
         byteVal = 0
         for i, v in enumerate(reversed(self.rawBits)):
-            byteVal += ( 1 << i ) * v
+            byteVal += (1 << i) * v
 
         return byteVal
 
@@ -349,7 +349,7 @@ def errcheck(ret, func, args):
 def _loadLinuxSo():
     try:
         l = ctypes.CDLL("liblabjackusb.so", use_errno=True)
-    except TypeError: # Python 2.5
+    except TypeError:  # Python 2.5
         l = ctypes.CDLL("liblabjackusb.so")
     l.LJUSB_Stream.errcheck = errcheck
     l.LJUSB_Read.errcheck = errcheck
@@ -358,7 +358,7 @@ def _loadLinuxSo():
 def _loadMacDylib():
     try:
         l = ctypes.CDLL("liblabjackusb.dylib", use_errno=True)
-    except TypeError: # Python 2.5
+    except TypeError:  # Python 2.5
         l = ctypes.CDLL("liblabjackusb.dylib")
     l.LJUSB_Stream.errcheck = errcheck
     l.LJUSB_Read.errcheck = errcheck
@@ -373,10 +373,10 @@ def _loadLibrary():
     _os_name = "nt"
     try:
         if sys.platform.startswith("win32"):
-            #Windows detected
+            # Windows detected
             return ctypes.WinDLL("ljackuw")
         if sys.platform.startswith("cygwin"):
-            #Cygwin detected. WinDLL not available, but CDLL seems to work.
+            # Cygwin detected. WinDLL not available, but CDLL seems to work.
             return ctypes.CDLL("ljackuw")
     except Exception:
         e = sys.exc_info()[1]
@@ -386,14 +386,14 @@ def _loadLibrary():
     addStr = "Exodriver"
     try:
         if sys.platform.startswith("linux"):
-            #Linux detected
+            # Linux detected
             addStr = "Linux SO"
             return _loadLinuxSo()
         if sys.platform.startswith("darwin"):
-            #Mac detected
+            # Mac detected
             addStr = "Mac Dylib"
             return _loadMacDylib()
-        #Other OS? Just try to load the Exodriver like a Linux SO
+        # Other OS? Just try to load the Exodriver like a Linux SO
         addStr = "Other SO"
         return _loadLinuxSo()
     except OSError:
@@ -418,7 +418,7 @@ class U12(object):
     u12 = U12()
 
     """
-    def __init__(self, id = -1, serialNumber = None, debug = False):
+    def __init__(self, id=-1, serialNumber=None, debug=False):
         self.id = id
         self.serialNumber = serialNumber
         self.deviceName = "U12"
@@ -434,7 +434,7 @@ class U12(object):
 
             self.open(id, serialNumber)
 
-    def open(self, id = -1, serialNumber = None):
+    def open(self, id=-1, serialNumber=None):
         """
         Opens the U12.
 
@@ -456,7 +456,7 @@ class U12(object):
                 numDevices = staticLib.LJUSB_GetDevCount(devType)
 
                 for i in range(numDevices):
-                    handle = openDev(i+1, 0, devType)
+                    handle = openDev(i + 1, 0, devType)
 
                     if handle != 0 and handle is not None:
                         self.handle = ctypes.c_void_p(handle)
@@ -478,7 +478,7 @@ class U12(object):
                 numDevices = staticLib.LJUSB_GetDevCount(devType)
 
                 for i in range(numDevices):
-                    handle = openDev(i+1, 0, devType)
+                    handle = openDev(i + 1, 0, devType)
 
                     if handle != 0 and handle is not None:
                         self.handle = ctypes.c_void_p(handle)
@@ -504,8 +504,8 @@ class U12(object):
                     self.handle = ctypes.c_void_p(handle)
 
                     # U12 ignores first command, so let's write a command.
-                    command = [ 0 ] * 8
-                    command[5] = 0x57 # 0b01010111
+                    command = [0] * 8
+                    command[5] = 0x57  # 0b01010111
 
                     try:
                         self.write(command)
@@ -540,14 +540,14 @@ class U12(object):
 
             if self.debug:
                 print("Writing: " + hexWithoutQuotes(writeBuffer))
-            newA = (ctypes.c_byte*len(writeBuffer))(0)
+            newA = (ctypes.c_byte * len(writeBuffer))(0)
             for i in range(len(writeBuffer)):
                 newA[i] = ctypes.c_byte(writeBuffer[i])
 
             writeBytes = staticLib.LJUSB_Write(self.handle, ctypes.byref(newA), len(writeBuffer))
 
             if writeBytes != len(writeBuffer):
-                raise U12Exception( "Could only write %s of %s bytes." % (writeBytes, len(writeBuffer) ) )
+                raise U12Exception("Could only write %s of %s bytes." % (writeBytes, len(writeBuffer)))
 
             return writeBuffer
 
@@ -557,7 +557,7 @@ class U12(object):
         else:
             if self.handle is None:
                 raise U12Exception("The U12's handle is None. Please open a U12 with open()")
-            newA = (ctypes.c_byte*numBytes)()
+            newA = (ctypes.c_byte * numBytes)()
             readBytes = staticLib.LJUSB_ReadTO(self.handle, ctypes.byref(newA), numBytes, timeout)
             # Return a list of integers in command-response mode
             result = [(newA[i] & 0xff) for i in range(readBytes)]
@@ -607,7 +607,7 @@ class U12(object):
 
     # Begin Section 5 Functions
 
-    def rawAISample(self, channel0PGAMUX = 8, channel1PGAMUX = 9, channel2PGAMUX = 10, channel3PGAMUX = 11, UpdateIO = False, LEDState = True, IO3toIO0States = 0, EchoValue = 0):
+    def rawAISample(self, channel0PGAMUX=8, channel1PGAMUX=9, channel2PGAMUX=10, channel3PGAMUX=11, UpdateIO=False, LEDState=True, IO3toIO0States=0, EchoValue=0):
         """
         Name: U12.rawAISample(channel0PGAMUX = 8, channel1PGAMUX = 9,
                               channel2PGAMUX = 10, channel3PGAMUX = 11,
@@ -652,33 +652,33 @@ class U12(object):
         }
 
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         # Bits 6-4: PGA for 1st Channel
         # Bits 3-0: MUX command for 1st Channel
         command[0] = int(channel0PGAMUX)
 
-        tempNum = command[0] & 7 # 7 = 0b111
-        channel0Number = tempNum if (command[0] & 0xf) > 7 else tempNum+8
-        channel0Gain = (command[0] >> 4) & 7 # 7 = 0b111
+        tempNum = command[0] & 7  # 7 = 0b111
+        channel0Number = tempNum if (command[0] & 0xf) > 7 else tempNum + 8
+        channel0Gain = (command[0] >> 4) & 7  # 7 = 0b111
 
         command[1] = int(channel1PGAMUX)
 
-        tempNum = command[1] & 7 # 7 = 0b111
-        channel1Number = tempNum if (command[1] & 0xf) > 7 else tempNum+8
-        channel1Gain = (command[1] >> 4) & 7 # 7 = 0b111
+        tempNum = command[1] & 7  # 7 = 0b111
+        channel1Number = tempNum if (command[1] & 0xf) > 7 else tempNum + 8
+        channel1Gain = (command[1] >> 4) & 7  # 7 = 0b111
 
         command[2] = int(channel2PGAMUX)
 
-        tempNum = command[2] & 7 # 7 = 0b111
-        channel2Number = tempNum if (command[2] & 0xf) > 7 else tempNum+8
-        channel2Gain = (command[2] >> 4) & 7 # 7 = 0b111
+        tempNum = command[2] & 7  # 7 = 0b111
+        channel2Number = tempNum if (command[2] & 0xf) > 7 else tempNum + 8
+        channel2Gain = (command[2] >> 4) & 7  # 7 = 0b111
 
         command[3] = int(channel3PGAMUX)
 
-        tempNum = command[3] & 7 # 7 = 0b111
-        channel3Number = tempNum if (command[3] & 0xf) > 7 else tempNum+8
-        channel3Gain = (command[3] >> 4) & 7 # 7 = 0b111
+        tempNum = command[3] & 7  # 7 = 0b111
+        channel3Number = tempNum if (command[3] & 0xf) > 7 else tempNum + 8
+        channel3Gain = (command[3] >> 4) & 7  # 7 = 0b111
 
         # Bit 1: Update IO
         # Bit 0: LED State
@@ -693,7 +693,7 @@ class U12(object):
         bf.bit7 = 1
         bf.bit6 = 1
 
-        bf.fromByte( int(bf) | int(IO3toIO0States) )
+        bf.fromByte(int(bf) | int(IO3toIO0States))
         command[5] = int(bf)
 
         command[7] = EchoValue
@@ -732,7 +732,7 @@ class U12(object):
 
         return returnDict
 
-    def rawDIO(self, D15toD8Directions = 0, D7toD0Directions = 0, D15toD8States = 0, D7toD0States = 0, IO3toIO0DirectionsAndStates = 0, UpdateDigital = False):
+    def rawDIO(self, D15toD8Directions=0, D7toD0Directions=0, D15toD8States=0, D7toD0States=0, IO3toIO0DirectionsAndStates=0, UpdateDigital=False):
         """
         Name: U12.rawDIO(D15toD8Directions = 0, D7toD0Directions = 0,
                          D15toD8States = 0, D7toD0States = 0,
@@ -803,7 +803,7 @@ class U12(object):
         }
 
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         # Bits for D15 through D8 Direction
         command[0] = int(D15toD8Directions)
@@ -822,12 +822,12 @@ class U12(object):
         command[4] = int(IO3toIO0DirectionsAndStates)
 
         # 01X10111 (DIO)
-        command[5] = 0x57 # 0b01010111
+        command[5] = 0x57  # 0b01010111
 
         # Bit 0: Update Digital
         command[6] = int(bool(UpdateDigital))
 
-        #XXXXXXXX
+        # XXXXXXXX
         # command[7] = XXXXXXXX
 
         self.write(command)
@@ -851,7 +851,7 @@ class U12(object):
 
         return returnDict
 
-    def rawCounter(self, StrobeEnabled = False, ResetCounter = False):
+    def rawCounter(self, StrobeEnabled=False, ResetCounter=False):
         """
         Name: U12.rawCounter(StrobeEnabled = False, ResetCounter = False)
         Args: StrobeEnable, set to True to enable strobe.
@@ -889,7 +889,7 @@ class U12(object):
 
 
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         bf = BitField()
         bf.bit1 = int(StrobeEnabled)
@@ -923,7 +923,7 @@ class U12(object):
 
         return returnDict
 
-    def rawCounterPWMDIO(self, D15toD8Directions = 0, D7toD0Directions = 0, D15toD8States = 0, D7toD0States = 0, IO3toIO0DirectionsAndStates = 0, ResetCounter = False, UpdateDigital = 0, PWMA = 0, PWMB = 0):
+    def rawCounterPWMDIO(self, D15toD8Directions=0, D7toD0Directions=0, D15toD8States=0, D7toD0States=0, IO3toIO0DirectionsAndStates=0, ResetCounter=False, UpdateDigital=0, PWMA=0, PWMB=0):
         """
         Name: U12.rawCounterPWMDIO( D15toD8Directions = 0, D7toD0Directions = 0,
                                     D15toD8States = 0, D7toD0States = 0,
@@ -976,7 +976,7 @@ class U12(object):
           'Counter': 0
         }
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         # Bits for D15 through D8 Direction
         command[0] = int(D15toD8Directions)
@@ -998,15 +998,15 @@ class U12(object):
         bf.bit5 = int(ResetCounter)
         bf.bit4 = int(UpdateDigital)
 
-        binPWMA = int((1023 * (float(PWMA)/5.0)))
-        binPWMB = int((1023 * (float(PWMB)/5.0)))
+        binPWMA = int((1023 * (float(PWMA) / 5.0)))
+        binPWMB = int((1023 * (float(PWMB) / 5.0)))
 
         bf2 = BitField()
-        bf2.fromByte( binPWMA & 3 ) # 3 = 0b11
+        bf2.fromByte(binPWMA & 3)  # 3 = 0b11
         bf.bit3 = bf2.bit1
         bf.bit2 = bf2.bit0
 
-        bf2.fromByte( binPWMB & 3 ) # 3 = 0b11
+        bf2.fromByte(binPWMB & 3)  # 3 = 0b11
         bf.bit1 = bf2.bit1
         bf.bit0 = bf2.bit0
 
@@ -1032,7 +1032,7 @@ class U12(object):
 
         return returnDict
 
-    def rawAIBurst(self, channel0PGAMUX = 8, channel1PGAMUX = 9, channel2PGAMUX = 10, channel3PGAMUX = 11, NumberOfScans = 8, TriggerIONum = 0, TriggerState = 0, UpdateIO = False, LEDState = True, IO3ToIO0States = 0, FeatureReports = False, TriggerOn = False, SampleInterval = 15000):
+    def rawAIBurst(self, channel0PGAMUX=8, channel1PGAMUX=9, channel2PGAMUX=10, channel3PGAMUX=11, NumberOfScans=8, TriggerIONum=0, TriggerState=0, UpdateIO=False, LEDState=True, IO3ToIO0States=0, FeatureReports=False, TriggerOn=False, SampleInterval=15000):
         """
         Name: U12.rawAIBurst( channel0PGAMUX = 8, channel1PGAMUX = 9,
                               channel2PGAMUX = 10, channel3PGAMUX = 11,
@@ -1116,33 +1116,33 @@ class U12(object):
 
 
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         # Bits 6-4: PGA for 1st Channel
         # Bits 3-0: MUX command for 1st Channel
         command[0] = int(channel0PGAMUX)
 
-        tempNum = command[0] & 7 # 7 = 0b111
-        channel0Number = tempNum if (command[0] & 0xf) > 7 else tempNum+8
-        channel0Gain = (command[0] >> 4) & 7 # 7 = 0b111
+        tempNum = command[0] & 7  # 7 = 0b111
+        channel0Number = tempNum if (command[0] & 0xf) > 7 else tempNum + 8
+        channel0Gain = (command[0] >> 4) & 7  # 7 = 0b111
 
         command[1] = int(channel1PGAMUX)
 
-        tempNum = command[1] & 7 # 7 = 0b111
-        channel1Number = tempNum if (command[1] & 0xf) > 7 else tempNum+8
-        channel1Gain = (command[1] >> 4) & 7 # 7 = 0b111
+        tempNum = command[1] & 7  # 7 = 0b111
+        channel1Number = tempNum if (command[1] & 0xf) > 7 else tempNum + 8
+        channel1Gain = (command[1] >> 4) & 7  # 7 = 0b111
 
         command[2] = int(channel2PGAMUX)
 
-        tempNum = command[2] & 7 # 7 = 0b111
-        channel2Number = tempNum if (command[2] & 0xf) > 7 else tempNum+8
-        channel2Gain = (command[2] >> 4) & 7 # 7 = 0b111
+        tempNum = command[2] & 7  # 7 = 0b111
+        channel2Number = tempNum if (command[2] & 0xf) > 7 else tempNum + 8
+        channel2Gain = (command[2] >> 4) & 7  # 7 = 0b111
 
         command[3] = int(channel3PGAMUX)
 
-        tempNum = command[3] & 7 # 7 = 0b111
-        channel3Number = tempNum if (command[3] & 0xf) > 7 else tempNum+8
-        channel3Gain = (command[3] >> 4) & 7 # 7 = 0b111
+        tempNum = command[3] & 7  # 7 = 0b111
+        channel3Number = tempNum if (command[3] & 0xf) > 7 else tempNum + 8
+        channel3Gain = (command[3] >> 4) & 7  # 7 = 0b111
 
         if NumberOfScans > 1024 or NumberOfScans < 8:
             raise U12Exception("The number of scans must be between 1024 and 8 (inclusive)")
@@ -1150,15 +1150,15 @@ class U12(object):
         NumScansExponentMod = 10 - int(math.ceil(math.log(NumberOfScans, 2)))
         NumScans = 2 ** (10 - NumScansExponentMod)
 
-        bf = BitField( rawByte = (NumScansExponentMod << 5) )
+        bf = BitField(rawByte=(NumScansExponentMod << 5))
         # bits 4-3: IO to Trigger on
         bf.bit2 = 0
         bf.bit1 = int(bool(UpdateIO))
         bf.bit0 = int(bool(LEDState))
         command[4] = int(bf)
 
-        bf2 = BitField(rawByte = int(IO3ToIO0States))
-        #Bits 7-4: 1010 (Start Burst)
+        bf2 = BitField(rawByte=int(IO3ToIO0States))
+        # Bits 7-4: 1010 (Start Burst)
         bf2.bit7 = 1
         bf2.bit5 = 1
         command[5] = int(bf2)
@@ -1166,7 +1166,7 @@ class U12(object):
         if SampleInterval < 733:
             raise U12Exception("SampleInterval must be greater than 733.")
 
-        bf3 = BitField( rawByte = ((SampleInterval >> 8) & 0xf) )
+        bf3 = BitField(rawByte=((SampleInterval >> 8) & 0xf))
         bf3.bit7 = int(bool(FeatureReports))
         bf3.bit6 = int(bool(TriggerOn))
         command[6] = int(bf3)
@@ -1198,7 +1198,7 @@ class U12(object):
         returnDict['Channel3'] = list()
 
         for results in resultsList:
-            bf = BitField(rawByte = results[0])
+            bf = BitField(rawByte=results[0])
 
             if bf.bit7 != 1 or bf.bit6 != 0:
                 raise U12Exception("Expected a AIBurst response, got %s instead." % results[0])
@@ -1231,14 +1231,14 @@ class U12(object):
 
 
 
-    def rawAIContinuous(self, channel0PGAMUX = 8, channel1PGAMUX = 9, channel2PGAMUX = 10, channel3PGAMUX = 11, FeatureReports = False, CounterRead = False, UpdateIO = False, LEDState = True, IO3ToIO0States = 0, SampleInterval = 15000):
+    def rawAIContinuous(self, channel0PGAMUX=8, channel1PGAMUX=9, channel2PGAMUX=10, channel3PGAMUX=11, FeatureReports=False, CounterRead=False, UpdateIO=False, LEDState=True, IO3ToIO0States=0, SampleInterval=15000):
         """
         Currently in development.
 
         The function is mostly implemented, but is currently too slow to be
         useful.
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         # Bits 6-4: PGA for 1st Channel
         # Bits 3-0: MUX command for 1st Channel
@@ -1256,13 +1256,13 @@ class U12(object):
         command[4] = int(bf)
 
         # Bits 7-4: 1001 (Start Continuous)
-        bf2 = BitField( rawByte = int(IO3ToIO0States) )
+        bf2 = BitField(rawByte=int(IO3ToIO0States))
         bf2.bit7 = 1
         bf2.bit4 = 1
 
         command[5] = int(bf2)
 
-        command[6] = ( SampleInterval >> 8)
+        command[6] = (SampleInterval >> 8)
         command[7] = SampleInterval & 0xff
 
         byte0bf = BitField()
@@ -1281,7 +1281,7 @@ class U12(object):
 
             yield returnDict
 
-    def rawPulseout(self, B1 = 10, C1 = 2, B2 = 10, C2 = 2, D7ToD0PulseSelection = 1, ClearFirst = False, NumberOfPulses = 5):
+    def rawPulseout(self, B1=10, C1=2, B2=10, C2=2, D7ToD0PulseSelection=1, ClearFirst=False, NumberOfPulses=5):
         """
         Name: U12.rawPulseout( B1 = 10, C1 = 2, B2 = 10, C2 = 2,
                                D7ToD0PulseSelection = 1, ClearFirst = False,
@@ -1345,7 +1345,7 @@ class U12(object):
         # Calculate how long the pulses should take, in milliseconds.
         # This plus 5 seconds is the read timeout like in the ljackuw/ul
         # library.
-        pulsesMS = int(NumberOfPulses * ((B1*C1*0.02)+(B2*C2*0.02)))
+        pulsesMS = int(NumberOfPulses * ((B1 * C1 * 0.02) + (B2 * C2 * 0.02)))
         timeoutMS = min(pulsesMS, 85226967)
         timeoutMS = max(timeoutMS, 1000) + 5000
         results = self.read(timeout=timeoutMS)
@@ -1376,7 +1376,7 @@ class U12(object):
         >>> d = u12.U12()
         >>> d.rawReset()
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         # 0b01011111 ( Reset )
         bf = BitField()
@@ -1409,7 +1409,7 @@ class U12(object):
         >>> d = u12.U12()
         >>> d.rawReenumerate()
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         # 0b01000000 (Re-Enumerate)
         bf = BitField()
@@ -1418,7 +1418,7 @@ class U12(object):
         self.write(command)
         self.close()
 
-    def rawWatchdog(self, IgnoreCommands = False, D0Active = False, D0State = False, D1Active = False, D1State = False, D8Active = False, D8State = False, ResetOnTimeout = False, WatchdogActive = False, Timeout = 60):
+    def rawWatchdog(self, IgnoreCommands=False, D0Active=False, D0State=False, D1Active=False, D1State=False, D8Active=False, D8State=False, ResetOnTimeout=False, WatchdogActive=False, Timeout=60):
         """
         Name: U12.rawWatchdog( IgnoreCommands = False, D0Active = False,
                                D0State = False, D1Active = False,
@@ -1440,7 +1440,7 @@ class U12(object):
         >>> print(d.rawWatchdog())
         {'FirmwareVersion': '1.10'}
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         command[0] = int(bool(IgnoreCommands))
 
@@ -1467,7 +1467,7 @@ class U12(object):
         # Timeout is increments of 2^16 cycles.
         # 2^16 cycles is about 0.01 seconds.
         binTimeout = int((float(Timeout) / 0.01))
-        command[6] = ( binTimeout >> 8 ) & 0xff
+        command[6] = (binTimeout >> 8) & 0xff
         command[7] = binTimeout & 0xff
 
         self.write(command)
@@ -1479,7 +1479,7 @@ class U12(object):
 
         return returnDict
 
-    def rawReadRAM(self, Address = 0):
+    def rawReadRAM(self, Address=0):
         """
         Name: U12.rawReadRAM(Address = 0)
 
@@ -1506,7 +1506,7 @@ class U12(object):
         >>> print(struct.unpack(">I", struct.pack("BBBB", *bytes))[0])
         100043690
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         # 01010000 (Read RAM)
         bf = BitField()
@@ -1560,7 +1560,7 @@ class U12(object):
         >>> print(d.rawWriteRAM([1, 2, 3, 4], 0x200))
         {'DataByte3': 4, 'DataByte2': 3, 'DataByte1': 2, 'DataByte0': 1}
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         if not isinstance(Data, list) or len(Data) > 4:
             raise U12Exception("Data wasn't a list, or was too long.")
@@ -1598,7 +1598,7 @@ class U12(object):
 
         return returnDict
 
-    def rawAsynch(self, Data, AddDelay = False, TimeoutActive = False, SetTransmitEnable = False, PortB = False, NumberOfBytesToWrite = 0, NumberOfBytesToRead = 0):
+    def rawAsynch(self, Data, AddDelay=False, TimeoutActive=False, SetTransmitEnable=False, PortB=False, NumberOfBytesToWrite=0, NumberOfBytesToRead=0):
         """
         Name: U12.rawAsynch(Data, AddDelay = False, TimeoutActive = False,
                             SetTransmitEnable = False, PortB = False,
@@ -1637,7 +1637,7 @@ class U12(object):
         }
 
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         if not isinstance(Data, list) or len(Data) > 4:
             raise U12Exception("Data wasn't a list, or was too long.")
@@ -1661,7 +1661,7 @@ class U12(object):
 
         command[4] = int(bf)
 
-        #01100001 (Asynch)
+        # 01100001 (Asynch)
         bf2 = BitField()
         bf2.bit6 = 1
         bf2.bit5 = 1
@@ -1684,13 +1684,13 @@ class U12(object):
         returnDict['DataByte0'] = results[3]
 
         bfLabels = ["Timeout Error Flag", "STRT Error Flag", "FRM Error Flag", "RXTris Error Flag", "TETris Error Flag", "TXTris Error Flag"]
-        bf = BitField( rawByte = results[4], labelPrefix = "", labelList = bfLabels )
+        bf = BitField(rawByte=results[4], labelPrefix="", labelList=bfLabels)
 
         returnDict["ErrorFlags"] = bf
 
         return returnDict
 
-    def rawSPI(self, Data, AddMsDelay = False, AddHundredUsDelay = False, SPIMode = 'A', NumberOfBytesToWriteRead = 0, ControlCS = False, StateOfActiveCS = False, CSLineNumber = 0):
+    def rawSPI(self, Data, AddMsDelay=False, AddHundredUsDelay=False, SPIMode='A', NumberOfBytesToWriteRead=0, ControlCS=False, StateOfActiveCS=False, CSLineNumber=0):
         """
         Name: U12.rawSPI( Data, AddMsDelay = False, AddHundredUsDelay = False,
                           SPIMode = 'A', NumberOfBytesToWriteRead = 0,
@@ -1728,7 +1728,7 @@ class U12(object):
         }
 
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         if not isinstance(Data, list) or len(Data) > 4:
             raise U12Exception("Data wasn't a list, or was too long.")
@@ -1753,7 +1753,7 @@ class U12(object):
             modeIndex = spiModes.index(SPIMode)
         except ValueError:
             raise U12Exception("Invalid SPIMode %r, valid modes are: %r" % (SPIMode, spiModes))
-        bf[7-modeIndex] = 1
+        bf[7 - modeIndex] = 1
 
         command[4] = int(bf)
 
@@ -1766,7 +1766,7 @@ class U12(object):
         command[5] = int(bf2)
         command[6] = NumberOfBytesToWriteRead
 
-        bf3 = BitField(rawByte = CSLineNumber)
+        bf3 = BitField(rawByte=CSLineNumber)
         bf3.bit7 = int(bool(ControlCS))
         bf3.bit6 = int(bool(StateOfActiveCS))
 
@@ -1785,13 +1785,13 @@ class U12(object):
         returnDict['DataByte0'] = results[3]
 
         bfLabels = ["CSStateTris Error Flag", "SCKTris Error Flag", "MISOTris Error Flag", "MOSITris Error Flag"]
-        bf = BitField( rawByte = results[4], labelPrefix = "", labelList = bfLabels )
+        bf = BitField(rawByte=results[4], labelPrefix="", labelList=bfLabels)
 
         returnDict["ErrorFlags"] = bf
 
         return returnDict
 
-    def rawSHT1X(self, Data = [3,0,0,0], WaitForMeasurementReady = True, IssueSerialReset = False, Add1MsDelay = False, Add300UsDelay = False, IO3State = 1, IO2State = 1, IO3Direction = 1, IO2Direction = 1, NumberOfBytesToWrite = 1, NumberOfBytesToRead = 3):
+    def rawSHT1X(self, Data=[3, 0, 0, 0], WaitForMeasurementReady=True, IssueSerialReset=False, Add1MsDelay=False, Add300UsDelay=False, IO3State=1, IO2State=1, IO3Direction=1, IO2Direction=1, NumberOfBytesToWrite=1, NumberOfBytesToRead=3):
         """
         Name: U12.rawSHT1X( Data = [3, 0, 0, 0],
                             WaitForMeasurementReady = True,
@@ -1861,7 +1861,7 @@ class U12(object):
         >>> print(rh)
         19.3360256
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
         if NumberOfBytesToWrite != 0:
             if not isinstance(Data, list) or len(Data) > 4:
@@ -1908,13 +1908,13 @@ class U12(object):
         returnDict['DataByte0'] = results[3]
 
         bfLabels = ["Serial Reset Error Flag", "Measurement Ready Error Flag", "Ack Error Flag"]
-        bf = BitField( rawByte = results[4], labelPrefix = "", labelList = bfLabels )
+        bf = BitField(rawByte=results[4], labelPrefix="", labelList=bfLabels)
 
         returnDict["ErrorFlags"] = bf
 
         return returnDict
 
-    def eAnalogIn(self, channel, idNum = None, demo=0, gain=0):
+    def eAnalogIn(self, channel, idNum=None, demo=0, gain=0):
         """
         Name: U12.eAnalogIn(channel, idNum = None, demo=0, gain=0)
         Args: See section 4.1 of the User's Guide
@@ -1937,18 +1937,18 @@ class U12(object):
 
             if ecode != 0: raise U12Exception(ecode)
 
-            return {"idnum":ljid.value, "overVoltage":ad0.value, "voltage":ad1.value}
+            return {"idnum": ljid.value, "overVoltage": ad0.value, "voltage": ad1.value}
         else:
             # Bits 6-4: PGA for 1st Channel
             # Bits 3-0: MUX command for 1st Channel
-            channel0PGAMUX = ( ( gain & 7 ) << 4)
-            channel0PGAMUX += channel-8 if channel > 7 else channel+8
+            channel0PGAMUX = ((gain & 7) << 4)
+            channel0PGAMUX += channel - 8 if channel > 7 else channel + 8
 
-            results = self.rawAISample(channel0PGAMUX = channel0PGAMUX)
+            results = self.rawAISample(channel0PGAMUX=channel0PGAMUX)
 
-            return {"idnum" : self.id, "overVoltage" : int(results['PGAOvervoltage']), 'voltage' : results['Channel0']}
+            return {"idnum": self.id, "overVoltage": int(results['PGAOvervoltage']), 'voltage': results['Channel0']}
 
-    def eAnalogOut(self, analogOut0, analogOut1, idNum = None, demo=0):
+    def eAnalogOut(self, analogOut0, analogOut1, idNum=None, demo=0):
         """
         Name: U12.eAnalogOut(analogOut0, analogOut1, idNum = None, demo=0)
         Args: See section 4.2 of the User's Guide
@@ -1968,7 +1968,7 @@ class U12(object):
 
             if ecode != 0: raise U12Exception(ecode)
 
-            return {"idnum":ljid.value}
+            return {"idnum": ljid.value}
         else:
             if analogOut0 < 0:
                 analogOut0 = self.pwmAVoltage
@@ -1976,14 +1976,14 @@ class U12(object):
             if analogOut1 < 0:
                 analogOut1 = self.pwmBVoltage
 
-            self.rawCounterPWMDIO(PWMA = analogOut0, PWMB = analogOut1)
+            self.rawCounterPWMDIO(PWMA=analogOut0, PWMB=analogOut1)
 
             self.pwmAVoltage = analogOut0
             self.pwmBVoltage = analogOut1
 
             return {"idnum": self.id}
 
-    def eCount(self, idNum = None, demo = 0, resetCounter = 0):
+    def eCount(self, idNum=None, demo=0, resetCounter=0):
         """
         Name: U12.eCount(idNum = None, demo = 0, resetCounter = 0)
         Args: See section 4.3 of the User's Guide
@@ -2008,14 +2008,14 @@ class U12(object):
 
             if ecode != 0: raise U12Exception(ecode)
 
-            return {"idnum":ljid.value, "count":count.value, "ms":ms.value}
+            return {"idnum": ljid.value, "count": count.value, "ms": ms.value}
         else:
-            results = self.rawCounter( ResetCounter = resetCounter)
+            results = self.rawCounter(ResetCounter=resetCounter)
 
-            return {"idnum":self.id, "count":results['Counter'], "ms": (time.time() * 1000)}
+            return {"idnum": self.id, "count": results['Counter'], "ms": (time.time() * 1000)}
 
 
-    def eDigitalIn(self, channel, idNum = None, demo = 0, readD=0):
+    def eDigitalIn(self, channel, idNum=None, demo=0, readD=0):
         """
         Name: U12.eDigitalIn(channel, idNum = None, demo = 0, readD=0)
         Args: See section 4.4 of the User's Guide
@@ -2041,33 +2041,33 @@ class U12(object):
 
             if ecode != 0: raise U12Exception(ecode)
 
-            return {"idnum":ljid.value, "state":state.value}
+            return {"idnum": ljid.value, "state": state.value}
         else:
             oldstate = self.rawDIO()
 
             if readD:
                 if channel > 7:
-                    channel = channel-8
-                    direction = BitField(rawByte = int(oldstate['D15toD8Directions']))
-                    direction[7-channel] = 1
+                    channel = channel - 8
+                    direction = BitField(rawByte=int(oldstate['D15toD8Directions']))
+                    direction[7 - channel] = 1
 
-                    results = self.rawDIO(D15toD8Directions = direction, UpdateDigital = True)
+                    results = self.rawDIO(D15toD8Directions=direction, UpdateDigital=True)
 
-                    state = results['D15toD8States'][7-channel]
+                    state = results['D15toD8States'][7 - channel]
 
                 else:
-                    direction = BitField(rawByte = int(oldstate['D7toD0Directions']))
-                    direction[7-channel] = 1
-                    results = self.rawDIO(D7toD0Directions = direction, UpdateDigital = True)
+                    direction = BitField(rawByte=int(oldstate['D7toD0Directions']))
+                    direction[7 - channel] = 1
+                    results = self.rawDIO(D7toD0Directions=direction, UpdateDigital=True)
 
-                    state = results['D7toD0States'][7-channel]
+                    state = results['D7toD0States'][7 - channel]
             else:
-                results = self.rawDIO(IO3toIO0DirectionsAndStates = 255, UpdateDigital = True)
-                state = results['IO3toIO0States'][3-channel]
+                results = self.rawDIO(IO3toIO0DirectionsAndStates=255, UpdateDigital=True)
+                state = results['IO3toIO0States'][3 - channel]
 
-            return {"idnum" : self.id, "state" : state}
+            return {"idnum": self.id, "state": state}
 
-    def eDigitalOut(self, channel, state, idNum = None, demo = 0, writeD=0):
+    def eDigitalOut(self, channel, state, idNum=None, demo=0, writeD=0):
         """
         Name: U12.eDigitalOut(channel, state, idNum = None, demo = 0, writeD=0)
         Args: See section 4.5 of the User's Guide
@@ -2092,37 +2092,37 @@ class U12(object):
 
             if ecode != 0: raise U12Exception(ecode)
 
-            return {"idnum":ljid.value}
+            return {"idnum": ljid.value}
         else:
             oldstate = self.rawDIO()
 
             if writeD:
                 if channel > 7:
-                    channel = channel-8
-                    direction = BitField(rawByte = int(oldstate['D15toD8Directions']))
-                    direction[7-channel] = 0
+                    channel = channel - 8
+                    direction = BitField(rawByte=int(oldstate['D15toD8Directions']))
+                    direction[7 - channel] = 0
 
-                    states = BitField(rawByte = int(oldstate['D15toD8States']))
-                    states[7-channel] = state
+                    states = BitField(rawByte=int(oldstate['D15toD8States']))
+                    states[7 - channel] = state
 
-                    self.rawDIO(D15toD8Directions = direction, D15toD8States = states, UpdateDigital = True)
+                    self.rawDIO(D15toD8Directions=direction, D15toD8States=states, UpdateDigital=True)
 
                 else:
-                    direction = BitField(rawByte = int(oldstate['D7toD0Directions']))
-                    direction[7-channel] = 0
+                    direction = BitField(rawByte=int(oldstate['D7toD0Directions']))
+                    direction[7 - channel] = 0
 
-                    states = BitField(rawByte = int(oldstate['D7toD0States']))
-                    states[7-channel] = state
+                    states = BitField(rawByte=int(oldstate['D7toD0States']))
+                    states[7 - channel] = state
 
-                    self.rawDIO(D7toD0Directions = direction, D7toD0States = states, UpdateDigital = True)
+                    self.rawDIO(D7toD0Directions=direction, D7toD0States=states, UpdateDigital=True)
 
             else:
                 bf = BitField()
-                bf[7-(channel+4)] = 0
-                bf[7-channel] = state
-                self.rawDIO(IO3toIO0DirectionsAndStates = bf, UpdateDigital = True)
+                bf[7 - (channel + 4)] = 0
+                bf[7 - channel] = state
+                self.rawDIO(IO3toIO0DirectionsAndStates=bf, UpdateDigital=True)
 
-            return {"idnum" : self.id}
+            return {"idnum": self.id}
 
     def aiSample(self, numChannels, channels, idNum=None, demo=0, stateIOin=0, updateIO=0, ledOn=0, gains=[0, 0, 0, 0], disableCal=0):
         """
@@ -2158,7 +2158,7 @@ class U12(object):
 
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value, "stateIO":stateIOin.value, "overVoltage":overVoltage.value, "voltages":voltages[0:numChannels]}
+        return {"idnum": idNum.value, "stateIO": stateIOin.value, "overVoltage": overVoltage.value, "voltages": voltages[0:numChannels]}
 
     def aiBurst(self, numChannels, channels, scanRate, numScans, idNum=None, demo=0, stateIOin=0, updateIO=0, ledOn=0, gains=[0, 0, 0, 0], disableCal=0, triggerIO=0, triggerState=0, timeout=1, transferMode=0):
         """
@@ -2194,7 +2194,7 @@ class U12(object):
 
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value, "scanRate":scanRate.value, "voltages":voltages, "stateIOout":stateIOout, "overVoltage":overVoltage.value}
+        return {"idnum": idNum.value, "scanRate": scanRate.value, "voltages": voltages, "stateIOout": stateIOout, "overVoltage": overVoltage.value}
 
     def aiStreamStart(self, numChannels, channels, scanRate, idNum=None, demo=0, stateIOin=0, updateIO=0, ledOn=0, gains=[0, 0, 0, 0], disableCal=0, readCount=0):
         """
@@ -2213,7 +2213,7 @@ class U12(object):
         # check list sizes
         if len(channels) < numChannels: raise ValueError("channels must have atleast numChannels elements")
         if len(gains) < numChannels: raise ValueError("gains must have atleast numChannels elements")
-        #if len(stateIOin) < 4: raise ValueError("stateIOin must have atleast 4 elements")
+        # if len(stateIOin) < 4: raise ValueError("stateIOin must have atleast 4 elements")
 
         # Check id number
         if idNum is None:
@@ -2227,14 +2227,14 @@ class U12(object):
 
         ecode = staticLib.AIStreamStart(ctypes.byref(idNum), demo, stateIOin, updateIO, ledOn, numChannels, ctypes.byref(channelsArray), ctypes.byref(gainsArray), ctypes.byref(scanRate), disableCal, 0, readCount)
 
-        if ecode != 0: raise U12Exception(ecode) # TODO: Switch this out for exception
+        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
 
         # The ID number must be saved for AIStream
         self.id = idNum.value
 
         self.streaming = True
 
-        return {"idnum":idNum.value, "scanRate":scanRate.value}
+        return {"idnum": idNum.value, "scanRate": scanRate.value}
 
     def aiStreamRead(self, numScans, localID=None, timeout=1):
         """
@@ -2267,9 +2267,9 @@ class U12(object):
 
         ecode = staticLib.AIStreamRead(localID, numScans, timeout, ctypes.byref(voltages), ctypes.byref(stateIOout), ctypes.byref(reserved), ctypes.byref(ljScanBacklog), ctypes.byref(overVoltage))
 
-        if ecode != 0: raise U12Exception(ecode) # TODO: Switch this out for exception
+        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
 
-        return {"voltages":voltages, "stateIOout":stateIOout, "reserved":reserved.value, "ljScanBacklog":ljScanBacklog.value, "overVoltage":overVoltage.value}
+        return {"voltages": voltages, "stateIOout": stateIOout, "reserved": reserved.value, "ljScanBacklog": ljScanBacklog.value, "overVoltage": overVoltage.value}
 
     def aiStreamClear(self, localID=None):
         """
@@ -2293,7 +2293,7 @@ class U12(object):
 
         ecode = staticLib.AIStreamClear(localID)
 
-        if ecode != 0: raise U12Exception(ecode) # TODO: Switch this out for exception
+        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
 
     def aoUpdate(self, idNum=None, demo=0, trisD=None, trisIO=None, stateD=None, stateIO=None, updateDigital=0, resetCounter=0, analogOut0=0, analogOut1=0):
         """
@@ -2328,9 +2328,9 @@ class U12(object):
         # Create arrays and other ctypes
         ecode = staticLib.AOUpdate(ctypes.byref(idNum), demo, trisD, trisIO, ctypes.byref(stateD), ctypes.byref(stateIO), updateDigital, resetCounter, ctypes.byref(count), ctypes.c_float(analogOut0), ctypes.c_float(analogOut1))
 
-        if ecode != 0: raise U12Exception(ecode) # TODO: Switch this out for exception
+        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
 
-        return {"idnum":idNum.value, "stateD":stateD.value, "stateIO":stateIO.value, "count":count.value}
+        return {"idnum": idNum.value, "stateD": stateD.value, "stateIO": stateIO.value, "count": count.value}
 
     def asynchConfig(self, fullA, fullB, fullC, halfA, halfB, halfC, idNum=None, demo=None, timeoutMult=1, configA=0, configB=0, configTE=0):
         """
@@ -2343,16 +2343,16 @@ class U12(object):
         >>> {'idNum': 1}
         """
 
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
 
         ecode = staticLib.AsynchConfig(ctypes.byref(idNum), demo, timeoutMult, configA, configB, configTE, fullA, fullB, fullC, halfA, halfB, halfC)
 
-        if ecode != 0: raise U12Exception(ecode) # TODO: Switch this out for exception
+        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
 
-        return {"idNum":idNum.value}
+        return {"idNum": idNum.value}
 
     def asynch(self, baudrate, data, idNum=None, demo=0, portB=0, enableTE=0, enableTO=0, enableDel=0, numWrite=0, numRead=0):
         """
@@ -2366,7 +2366,7 @@ class U12(object):
         >>> {'data': <u12.c_long_Array_18 object at 0x00DEFB70>, 'idnum': <type 'long'>}
         """
 
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2382,11 +2382,11 @@ class U12(object):
 
         ecode = staticLib.Asynch(ctypes.byref(idNum), demo, portB, enableTE, enableTO, enableDel, baudrate, numWrite, numRead, ctypes.byref(dataArray))
 
-        if ecode != 0: raise U12Exception(ecode) # TODO: Switch this out for exception
+        if ecode != 0: raise U12Exception(ecode)  # TODO: Switch this out for exception
 
-        return {"idnum":long, "data":dataArray}
+        return {"idnum": long, "data": dataArray}
 
-    GainMapping = [ 1.0, 2.0, 4.0, 5.0, 8.0, 10.0, 16.0, 20.0 ]
+    GainMapping = [1.0, 2.0, 4.0, 5.0, 8.0, 10.0, 16.0, 20.0]
     def bitsToVolts(self, chnum, chgain, bits):
         """
         Name: U12.bitsToVolts(chnum, chgain, bits)
@@ -2407,9 +2407,9 @@ class U12(object):
             return volts.value
         else:
             if chnum < 8:
-                return ( float(bits) * 20.0 / 4096.0 ) - 10.0
+                return (float(bits) * 20.0 / 4096.0) - 10.0
             else:
-                volts = ( float(bits) * 40.0 / 4096.0 ) - 20.0
+                volts = (float(bits) * 40.0 / 4096.0) - 20.0
                 return volts / self.GainMapping[chgain]
 
     def voltsToBits(self, chnum, chgain, volts):
@@ -2431,7 +2431,7 @@ class U12(object):
             return bits.value
         else:
             pass
-            #*bits = RoundFL((volts+10.0F)/(20.0F/4096.0F));
+            # *bits = RoundFL((volts+10.0F)/(20.0F/4096.0F));
 
     def counter(self, idNum=None, demo=0, resetCounter=0, enableSTB=1):
         """
@@ -2444,7 +2444,7 @@ class U12(object):
         >>> {'bits': 2662}
         """
 
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2458,7 +2458,7 @@ class U12(object):
 
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value, "stateD": stateD.value, "stateIO":stateIO.value, "count":count.value}
+        return {"idnum": idNum.value, "stateD": stateD.value, "stateIO": stateIO.value, "count": count.value}
 
     def digitalIO(self, idNum=None, demo=0, trisD=None, trisIO=None, stateD=None, stateIO=None, updateDigital=0):
         """
@@ -2471,7 +2471,7 @@ class U12(object):
         >>> {'stateIO': 0, 'stateD': 0, 'idnum': 1, 'outputD': 0, 'trisD': 0}
         """
 
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2485,8 +2485,8 @@ class U12(object):
 
         # Create ctypes
         if trisD is None: trisD = ctypes.c_long(999)
-        else:trisD = ctypes.c_long(trisD)
-        if stateD is None:stateD = ctypes.c_long(999)
+        else: trisD = ctypes.c_long(trisD)
+        if stateD is None: stateD = ctypes.c_long(999)
         else: stateD = ctypes.c_long(stateD)
         if stateIO is None: stateIO = ctypes.c_long(0)
         else: stateIO = ctypes.c_long(stateIO)
@@ -2498,7 +2498,7 @@ class U12(object):
         ecode = staticLib.DigitalIO(ctypes.byref(idNum), demo, ctypes.byref(trisD), trisIO, ctypes.byref(stateD), ctypes.byref(stateIO), updateDigital, ctypes.byref(outputD))
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value, "trisD":trisD.value, "stateD":stateD.value, "stateIO":stateIO.value, "outputD":outputD.value}
+        return {"idnum": idNum.value, "trisD": trisD.value, "stateD": stateD.value, "stateIO": stateIO.value, "outputD": outputD.value}
 
     def getDriverVersion(self):
         """
@@ -2531,9 +2531,9 @@ class U12(object):
         staticLib.GetFirmwareVersion.restype = ctypes.c_float
         firmware = staticLib.GetFirmwareVersion(ctypes.byref(idNum))
 
-        if firmware > 512: raise U12Exception(firmware-512)
+        if firmware > 512: raise U12Exception(firmware - 512)
 
-        return {"idnum" : idNum.value, "firmware" : firmware}
+        return {"idnum": idNum.value, "firmware": firmware}
 
     def getWinVersion(self):
         """
@@ -2558,7 +2558,7 @@ class U12(object):
 
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"majorVersion":majorVersion.value, "minorVersion":minorVersion.value, "buildNumber":buildNumber.value, "platformID":platformID.value, "servicePackMajor":servicePackMajor.value, "servicePackMinor":servicePackMinor.value}
+        return {"majorVersion": majorVersion.value, "minorVersion": minorVersion.value, "buildNumber": buildNumber.value, "platformID": platformID.value, "servicePackMajor": servicePackMajor.value, "servicePackMinor": servicePackMinor.value}
 
     def listAll(self):
         """
@@ -2572,10 +2572,10 @@ class U12(object):
         """
 
         # Create arrays and ctypes
-        productIDList = listToCArray([0]*127, ctypes.c_long)
-        serialnumList = listToCArray([0]*127, ctypes.c_long)
-        localIDList = listToCArray([0]*127, ctypes.c_long)
-        powerList = listToCArray([0]*127, ctypes.c_long)
+        productIDList = listToCArray([0] * 127, ctypes.c_long)
+        serialnumList = listToCArray([0] * 127, ctypes.c_long)
+        localIDList = listToCArray([0] * 127, ctypes.c_long)
+        powerList = listToCArray([0] * 127, ctypes.c_long)
         arr127_type = ctypes.c_long * 127
         calMatrix_type = arr127_type * 20
         calMatrix = calMatrix_type()
@@ -2585,7 +2585,7 @@ class U12(object):
         ecode = staticLib.ListAll(ctypes.byref(productIDList), ctypes.byref(serialnumList), ctypes.byref(localIDList), ctypes.byref(powerList), ctypes.byref(calMatrix), ctypes.byref(numberFound), ctypes.byref(reserved), ctypes.byref(reserved))
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"serialnumList": serialnumList, "localIDList":localIDList, "numberFound":numberFound.value}
+        return {"serialnumList": serialnumList, "localIDList": localIDList, "numberFound": numberFound.value}
 
     def localID(self, localID, idNum=None):
         """
@@ -2597,7 +2597,7 @@ class U12(object):
         >>> dev.localID(1)
         >>> {'idnum':1}
         """
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2605,7 +2605,7 @@ class U12(object):
         ecode = staticLib.LocalID(ctypes.byref(idNum), localID)
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value}
+        return {"idnum": idNum.value}
 
     def noThread(self, noThread, idNum=None):
         """
@@ -2617,7 +2617,7 @@ class U12(object):
         >>> dev.noThread(1)
         >>> {'idnum':1}
         """
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2625,7 +2625,7 @@ class U12(object):
         ecode = staticLib.NoThread(ctypes.byref(idNum), noThread)
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value}
+        return {"idnum": idNum.value}
 
     def pulseOut(self, bitSelect, numPulses, timeB1, timeC1, timeB2, timeC2, idNum=None, demo=0, lowFirst=0):
         """
@@ -2638,7 +2638,7 @@ class U12(object):
         >>> {'idnum':1}
         """
 
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2646,7 +2646,7 @@ class U12(object):
         ecode = staticLib.PulseOut(ctypes.byref(idNum), demo, lowFirst, bitSelect, numPulses, timeB1, timeC1, timeB2, timeC2)
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value}
+        return {"idnum": idNum.value}
 
     def pulseOutStart(self, bitSelect, numPulses, timeB1, timeC1, timeB2, timeC2, idNum=None, demo=0, lowFirst=0):
         """
@@ -2659,7 +2659,7 @@ class U12(object):
         >>> {'idnum':1}
         """
 
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2667,7 +2667,7 @@ class U12(object):
         ecode = staticLib.PulseOutStart(ctypes.byref(idNum), demo, lowFirst, bitSelect, numPulses, timeB1, timeC1, timeB2, timeC2)
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value}
+        return {"idnum": idNum.value}
 
     def pulseOutFinish(self, timeoutMS, idNum=None, demo=0):
         """
@@ -2680,7 +2680,7 @@ class U12(object):
         >>> dev.pulseOutFinish(100)
         >>> {'idnum':1}
         """
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2688,7 +2688,7 @@ class U12(object):
         ecode = staticLib.PulseOutFinish(ctypes.byref(idNum), demo, timeoutMS)
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value}
+        return {"idnum": idNum.value}
 
     def pulseOutCalc(self, frequency):
         """
@@ -2709,7 +2709,7 @@ class U12(object):
         ecode = staticLib.PulseOutCalc(ctypes.byref(frequency), ctypes.byref(timeB), ctypes.byref(timeC))
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"frequency":frequency.value, "timeB":timeB.value, "timeC":timeC.value}
+        return {"frequency": frequency.value, "timeB": timeB.value, "timeC": timeC.value}
 
     def reEnum(self, idNum=None):
         """
@@ -2722,7 +2722,7 @@ class U12(object):
         >>> {'idnum': 1}
         """
 
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2730,7 +2730,7 @@ class U12(object):
         ecode = staticLib.ReEnum(ctypes.byref(idNum))
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value}
+        return {"idnum": idNum.value}
 
     def reset(self, idNum=None):
         """
@@ -2743,7 +2743,7 @@ class U12(object):
         >>> {'idnum': 1}
         """
 
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2751,7 +2751,7 @@ class U12(object):
         ecode = staticLib.Reset(ctypes.byref(idNum))
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value}
+        return {"idnum": idNum.value}
 
     def resetLJ(self, idNum=None):
         """
@@ -2775,7 +2775,7 @@ class U12(object):
         >>> dev.sht1X()
         >>> {'tempC': 24.69999885559082, 'rh': 39.724445343017578, 'idnum': 1, 'tempF': 76.459999084472656}
         """
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2788,7 +2788,7 @@ class U12(object):
         ecode = staticLib.SHT1X(ctypes.byref(idNum), demo, softComm, mode, statusReg, ctypes.byref(tempC), ctypes.byref(tempF), ctypes.byref(rh))
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value, "tempC":tempC.value, "tempF":tempF.value, "rh":rh.value}
+        return {"idnum": idNum.value, "tempC": tempC.value, "tempF": tempF.value, "rh": rh.value}
 
     def shtComm(self, numWrite, numRead, datatx, idNum=None, softComm=0, waitMeas=0, serialReset=0, dataRate=0):
         """
@@ -2797,7 +2797,7 @@ class U12(object):
         Desc: Low-level public function to send and receive up to 4 bytes to from an SHT1X sensor
         """
 
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2812,7 +2812,7 @@ class U12(object):
         ecode = staticLib.SHTComm(ctypes.byref(idNum), softComm, waitMeas, serialReset, dataRate, numWrite, numRead, ctypes.byref(datatx), ctypes.byref(datarx))
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value, "datarx":datarx}
+        return {"idnum": idNum.value, "datarx": datarx}
 
     def shtCRC(self, numWrite, numRead, datatx, datarx, statusReg=0):
         """
@@ -2832,7 +2832,7 @@ class U12(object):
         Args: See section 4.35 of the User's Guide
         Desc: This function retrieves temperature and/or humidity readings from an SHT1X sensor.
         """
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2848,7 +2848,7 @@ class U12(object):
         ecode = staticLib.Synch(ctypes.byref(idNum), demo, mode, msDelay, husDelay, controlCS, csLine, csState, configD, numWriteRead, ctypes.byref(cData))
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value, "data":cData}
+        return {"idnum": idNum.value, "data": cData}
 
     def watchdog(self, active, timeout, activeDn, stateDn, idNum=None, demo=0, reset=0):
         """
@@ -2861,7 +2861,7 @@ class U12(object):
         >>> {'idnum': 1}
         """
 
-        #Check id number
+        # Check id number
         if idNum is None:
             idNum = self.id
         idNum = ctypes.c_long(idNum)
@@ -2872,9 +2872,9 @@ class U12(object):
         ecode = staticLib.Watchdog(ctypes.byref(idNum), demo, active, timeout, reset, activeDn[0], activeDn[1], activeDn[2], stateDn[0], stateDn[1], stateDn[2])
         if ecode != 0: raise U12Exception(ecode)
 
-        return {"idnum":idNum.value}
+        return {"idnum": idNum.value}
 
-    def readMem(self, address, idnum = None):
+    def readMem(self, address, idnum=None):
         """
         Name: U12.readMem(address, idnum=None)
         Args: See section 4.36 of the User's Guide
@@ -2979,7 +2979,7 @@ def getErrorString(errorcode):
     >>> dev.getErrorString(1)
     >>> Unkown error
     """
-    errorString = ctypes.c_char_p(" "*50)
+    errorString = ctypes.c_char_p(" " * 50)
     staticLib.GetErrorString(errorcode, errorString)
     return errorString.value
 

--- a/src/u12.py
+++ b/src/u12.py
@@ -1231,7 +1231,6 @@ class U12(object):
 
         return returnDict
 
-
     def rawAIContinuous(self, channel0PGAMUX=8, channel1PGAMUX=9, channel2PGAMUX=10, channel3PGAMUX=11, FeatureReports=False, CounterRead=False, UpdateIO=False, LEDState=True, IO3ToIO0States=0, SampleInterval=15000):
         """
         Currently in development.
@@ -2017,7 +2016,6 @@ class U12(object):
 
             return {"idnum": self.id, "count": results['Counter'], "ms": (time.time() * 1000)}
 
-
     def eDigitalIn(self, channel, idNum=None, demo=0, readD=0):
         """
         Name: U12.eDigitalIn(channel, idNum = None, demo = 0, readD=0)
@@ -2417,6 +2415,7 @@ class U12(object):
         return {"idnum": long, "data": dataArray}
 
     GainMapping = [1.0, 2.0, 4.0, 5.0, 8.0, 10.0, 16.0, 20.0]
+
     def bitsToVolts(self, chnum, chgain, bits):
         """
         Name: U12.bitsToVolts(chnum, chgain, bits)

--- a/src/u3.py
+++ b/src/u3.py
@@ -2636,7 +2636,7 @@ class TimerStopInput1(Timer1):
     [(0, 0)]
     """
     def __init__(self, UpdateReset = False, Value = 0):
-        Timer.__init__(self, 1, UpdateReset, Value, Mode = 9)
+        Timer1.__init__(self, UpdateReset, Value, Mode = 9)
 
     def __repr__(self):
         return "<u3.TimerStopInput1( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)

--- a/src/u3.py
+++ b/src/u3.py
@@ -7,7 +7,7 @@ Desc: Defines the U3 class, which makes working with a U3 much easier. All of
 
 To learn about the low-level functions, please see Section 5.2 of the U3 User's Guide:
 
-http://labjack.com/support/u3/users-guide/5.2 
+http://labjack.com/support/u3/users-guide/5.2
 
 Section Number Mapping:
 1 = Object Functions
@@ -46,7 +46,7 @@ CIO0, CIO1, CIO2, CIO3 = range(20)
 
 def openAllU3():
     """
-    A helpful function which will open all the connected U3s. Returns a 
+    A helpful function which will open all the connected U3s. Returns a
     dictionary where the keys are the serialNumber, and the value is the device
     object.
     """
@@ -62,7 +62,7 @@ def openAllU3():
 class U3(Device):
     """
     U3 Class for all U3 specific low-level commands.
-    
+
     Example:
     >>> import u3
     >>> d = u3.U3()
@@ -76,7 +76,7 @@ class U3(Device):
         Args: debug, enables debug output
               autoOpen, if true, the class will try to open a U3 using openArgs
               **openArgs, the arguments to pass to the open call. See U3.open()
-        
+
         Desc: Instantiates a new U3 object. If autoOpen == True, then it will
               also open a U3.
 
@@ -84,7 +84,7 @@ class U3(Device):
         Simplest:
         >>> import u3
         >>> d = u3.U3()
-        
+
         For debug output:
         >>> import u3
         >>> d = u3.U3(debug = True)
@@ -106,29 +106,29 @@ class U3(Device):
         """
         Name: U3.open(firstFound = True, localId = None, devNumber = None,
                       handleOnly = False, LJSocket = None)
-        
+
         Args: firstFound, If True, use the first found U3
               serial, open a U3 with the given serial number
               localId, open a U3 with the given local id.
               devNumber, open a U3 with the given devNumber
               handleOnly, if True, LabJackPython will only open a handle
               LJSocket, set to "<ip>:<port>" to connect to LJSocket
-        
+
         Desc: Use to open a U3. If handleOnly is false, it will call configU3
               and save the resulting information to the object. This allows the
               use of d.serialNumber, d.firmwareVersion, etc.
-        
+
         Examples:
         Simplest:
         >>> import u3
         >>> d = u3.U3(autoOpen = False)
         >>> d.open()
-        
+
         Handle-only, with a serial number = 320095789:
         >>> import u3
         >>> d = u3.U3(autoOpen = False)
         >>> d.open(handleOnly = True, serial = 320095789)
-        
+
         Using LJSocket:
         >>> import u3
         >>> d = u3.U3(autoOpen = False)
@@ -157,7 +157,7 @@ class U3(Device):
          'DeviceName': 'U3-LV',
          'FIODirection': 0,
          'FirmwareVersion': '1.24',
-         ... , 
+         ... ,
          'ProductID': 3
         }
 
@@ -168,7 +168,7 @@ class U3(Device):
         {
          'FIOAnalog': 255,
          'EIOAnalog': 255,
-         ... , 
+         ... ,
          'ProductID': 3
         }
         """
@@ -293,11 +293,11 @@ class U3(Device):
     def configIO(self, TimerCounterPinOffset = None, EnableCounter1 = None, EnableCounter0 = None, NumberOfTimersEnabled = None, FIOAnalog = None, EIOAnalog = None, EnableUART = None):
         """
         Name: U3.configIO(TimerCounterPinOffset = 4, EnableCounter1 = None, EnableCounter0 = None, NumberOfTimersEnabled = None, FIOAnalog = None, EIOAnalog = None, EnableUART = None)
-        
+
         Args: See section 5.2.3 of the user's guide.
-        
+
         Desc: The configIO command.
-        
+
         Examples:
         Simplest:
         >>> import u3
@@ -313,7 +313,7 @@ class U3(Device):
          'EnableCounter1': False,
          'EnableCounter0': False
         }
-        
+
         Set all FIOs and EIOs to digital (until power cycle):
         >>> import u3
         >>> d = u3.U3()
@@ -330,26 +330,26 @@ class U3(Device):
         }
 
         """
-        
+
         writeMask = 0
-        
+
         if EIOAnalog is not None:
             writeMask |= 1
             writeMask |= 8
-        
+
         if FIOAnalog is not None:
             writeMask |= 1
             writeMask |= 4
-            
+
         if EnableUART is not None:
             writeMask |= 1
             writeMask |= (1 << 5)
-            
+
         if TimerCounterPinOffset is not None or EnableCounter1 is not None or EnableCounter0 is not None or NumberOfTimersEnabled is not None :
             writeMask |= 1
-        
+
         command = [ 0 ] * 12
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x03
@@ -359,58 +359,58 @@ class U3(Device):
         command[6] = writeMask
         #command[7] = Reserved
         command[8] = 0
-        
+
         if EnableUART is not None:
             command[9] = int(EnableUART) << 2
-        
+
         if TimerCounterPinOffset is None:
             command[8] |= ( 4 & 15 ) << 4
         else:
             command[8] |= ( TimerCounterPinOffset & 15 ) << 4
-            
+
         if EnableCounter1 is not None:
             command[8] |= 1 << 3
         if EnableCounter0 is not None:
             command[8] |= 1 << 2
         if NumberOfTimersEnabled is not None:
             command[8] |= ( NumberOfTimersEnabled & 3 )
-            
+
         if FIOAnalog is not None:
             command[10] = FIOAnalog
-        
+
         if EIOAnalog is not None:
             command[11] = EIOAnalog
-        
+
         result = self._writeRead(command, 12, [0xF8, 0x03, 0x0B])
-        
+
         self.timerCounterConfig = result[8]
-        
+
         self.numberTimersEnabled = self.timerCounterConfig & 3
         self.counter0Enabled = bool( (self.timerCounterConfig >> 2) & 1 )
         self.counter1Enabled = bool( (self.timerCounterConfig >> 3) & 1 )
         self.timerCounterPinOffset = ( self.timerCounterConfig >> 4 )
-        
-        
+
+
         self.dac1Enable = result[9]
         self.fioAnalog = result[10]
         self.eioAnalog = result[11]
-        
+
         return { 'TimerCounterConfig' : self.timerCounterConfig, 'DAC1Enable' : self.dac1Enable, 'FIOAnalog' : self.fioAnalog, 'EIOAnalog' : self.eioAnalog, 'NumberOfTimersEnabled' : self.numberTimersEnabled, 'EnableCounter0' : self.counter0Enabled, 'EnableCounter1' : self.counter1Enabled, 'TimerCounterPinOffset' : self.timerCounterPinOffset }
     configIO.section = 2
-    
+
     def configTimerClock(self, TimerClockBase = None, TimerClockDivisor = None):
         """
         Name: U3.configTimerClock(TimerClockBase = None, TimerClockDivisor = None)
         Args: TimeClockBase, the base for the timer clock.
               TimerClockDivisor, the divisor for the clock.
-        
+
         Desc: Writes and reads the time clock configuration. See section 5.2.4
               of the user's guide.
-        
+
         Note: TimerClockBase and TimerClockDivisor must be set at the same time.
         """
         command = [ 0 ] * 10
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
@@ -425,23 +425,23 @@ class U3(Device):
                 command[9] =  TimerClockDivisor
         elif TimerClockDivisor is not None:
             raise LabJackException("You can't set just the divisor, must set both.")
-        
+
         result = self._writeRead(command, 10, [0xf8, 0x02, 0x0A])
-        
+
         self.timerClockBase = ( result[8] & 7 )
         self.timerClockDivisor = result[9]
-        
+
         return { 'TimerClockBase' : self.timerClockBase, 'TimerClockDivisor' : self.timerClockDivisor }
     configTimerClock.section = 2
 
     def toggleLED(self):
         """
         Name: U3.toggleLED()
-        
+
         Args: None
-        
+
         Desc: Toggles the state LED on and off.
-        
+
         Example:
         >>> import u3
         >>> d = u3.U3()
@@ -450,7 +450,7 @@ class U3(Device):
         self.getFeedback( LED( not self.ledState ) )
         self.ledState = not self.ledState
     toggleLED.section = 3
-    
+
     def setFIOState(self, fioNum, state = 1):
         """
         Name: U3.setFIOState(fioNum, state = 1)
@@ -460,7 +460,7 @@ class U3(Device):
               set the direction to output.  Note that this function can set
               all digital I/O lines (FIO0 - CIO3), and is equivalent to using
               the setDOState method.
-        
+
         Example:
         >>> import u3
         >>> d = u3.U3()
@@ -468,17 +468,17 @@ class U3(Device):
         """
         self.getFeedback(BitDirWrite(fioNum, 1), BitStateWrite(fioNum, state))
     setFIOState.section = 3
-    
+
     def getFIOState(self, fioNum):
         """
         Name: U3.getFIOState(fioNum)
-        
+
         Args: fioNum, which FIO to read
-        
+
         Desc: A convenience function to read the state of an FIO.  Note that
               this function can read all digital I/O lines (FIO0 - CIO3), and
               is equivalent to using the getDIOState method.
-        
+
         Example:
         >>> import u3
         >>> d = u3.U3()
@@ -498,7 +498,7 @@ class U3(Device):
               state, 1 = High, 0 = Low
         Desc: A convenience function to set the state of a digital I/O. Will
               also set the direction to output.
-        
+
         Example:
         >>> import u3
         >>> d = u3.U3()
@@ -516,7 +516,7 @@ class U3(Device):
                   16 - 19 = CIO0 - CIO3
         Desc: A convenience function to read the state of a digital I/O.  Will
               also set the direction to input.
-        
+
         Example:
         >>> import u3
         >>> d = u3.U3()
@@ -535,7 +535,7 @@ class U3(Device):
                   16 - 19 = CIO0 - CIO3
         Desc: A convenience function to read the state of a digital I/O.  Will
               not change the direction.
-        
+
         Example:
         >>> import u3
         >>> d = u3.U3()
@@ -548,19 +548,19 @@ class U3(Device):
     def getTemperature(self):
         """
         Name: U3.getTemperature()
-        
+
         Args: None
-        
+
         Desc: Reads the internal temperature sensor on the U3. Returns the
               temperature in Kelvin.
         """
-        
+
         # Get the calibration data first, otherwise the conversion is way off (10 degC on my U3)
         if self.calData is None:
             self.getCalibrationData()
 
         bits, = self.getFeedback( AIN(30, 31) )
-        
+
         return self.binaryToCalibratedAnalogTemperature(bits)
 
     def getAIN(self, posChannel, negChannel = 31, longSettle=False, quickSample=False):
@@ -572,9 +572,9 @@ class U3(Device):
               negChannel, the negitive channel to read from.
               longSettle, set to True for longSettle
               quickSample, set to True for quickSample
-        
+
         Desc: A convenience function to read an AIN.
-        
+
         Example:
         >>> import u3
         >>> d = u3.U3()
@@ -702,7 +702,7 @@ class U3(Device):
                 sendBuffer, readLen = self._buildBuffer(sendBuffer, readLen, cmd)
         return (sendBuffer, readLen)
     _buildBuffer.section = 4
-                
+
     def _buildFeedbackResults(self, rcvBuffer, commandlist, results, i):
         """
         Builds the result list from the results of getFeedback
@@ -719,11 +719,11 @@ class U3(Device):
     def getFeedback(self, *commandlist):
         """
         Name: U3.getFeedback(commandlist)
-        
+
         Args: the FeedbackCommands to run
-        
+
         Desc: Forms the commandlist into a packet, sends it to the U3, and reads the response.
-        
+
         Examples:
         >>> myU3 = u3.U3()
         >>> ledCommand = u3.LED(False)
@@ -732,16 +732,16 @@ class U3(Device):
         [None, 9376]
 
         OR if you like the list version better:
-        
+
         >>> myU3 = U3()
         >>> ledCommand = u3.LED(False)
         >>> ain0Command = u3.AIN(30, 31, True)
         >>> commandList = [ ledCommand, ain0Command ]
         >>> myU3.getFeedback(commandList)
         [None, 9376]
-        
+
         """
-        
+
         sendBuffer = [0] * 7
         sendBuffer[1] = 0xF8
         readLen = 9
@@ -749,23 +749,23 @@ class U3(Device):
         if len(sendBuffer) % 2:
             sendBuffer += [0]
         sendBuffer[2] = len(sendBuffer) // 2 - 3
-        
+
         if readLen % 2:
             readLen += 1
-            
-        
+
+
         if len(sendBuffer) > MAX_USB_PACKET_LENGTH:
             raise LabJackException("ERROR: The feedback command you are attempting to send is bigger than 64 bytes ( %s bytes ). Break your commands up into separate calls to getFeedback()." % len(sendBuffer))
-        
+
         if readLen > MAX_USB_PACKET_LENGTH:
             raise LabJackException("ERROR: The feedback command you are attempting to send would yield a response that is greater than 64 bytes ( %s bytes ). Break your commands up into separate calls to getFeedback()." % readLen)
-        
+
         rcvBuffer = self._writeRead(sendBuffer, readLen, [], checkBytes = False, stream = False, checksum = True)
-        
+
         # Check the response for errors
         try:
             self._checkCommandBytes(rcvBuffer, [0xF8])
-        
+
             if rcvBuffer[3] != 0x00:
                 raise LabJackException("Got incorrect command bytes")
         except LowlevelErrorException:
@@ -773,30 +773,30 @@ class U3(Device):
                 culprit = commandlist[0][ (rcvBuffer[7] -1) ]
             else:
                 culprit = commandlist[ (rcvBuffer[7] -1) ]
-            
+
             raise LowlevelErrorException("\nThis Command\n    %s\nreturned an error:\n    %s" %  (culprit , lowlevelErrorToString(rcvBuffer[6])))
-            
-        
+
+
         results = []
         i = 9
         return self._buildFeedbackResults(rcvBuffer, commandlist, results, i)
-    getFeedback.section = 2    
-    
+    getFeedback.section = 2
+
     def readMem(self, blockNum, readCal=False):
         """
         Name: U3.readMem(blockNum, readCal=False)
-        
+
         Args: blockNum, which block to read from
               readCal, set to True to read from calibration instead.
-        
+
         Desc: Reads 1 block (32 bytes) from the non-volatile user or
               calibration memory. Please read section 5.2.6 of the user's guide
               before you do something you may regret.
-        
+
         NOTE: Do not call this function while streaming.
         """
         command = [ 0 ] * 8
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
@@ -807,46 +807,46 @@ class U3(Device):
         #command[5] = Checksum16 (MSB)
         command[6] = 0x00
         command[7] = blockNum
-        
+
         result = self._writeRead(command, 40, [0xF8, 0x11, command[3]])
-        
+
         return result[8:]
     readMem.section = 2
-     
+
     def readCal(self, blockNum):
         """
         Name: U3.readCal(blockNum)
-        
+
         Args: blockNum, which block to read
-        
+
         Desc: See the description of readMem and section 5.2.6 of the user's
               guide.
-        
+
         Note: Do not call this function while streaming.
         """
         return self.readMem(blockNum, readCal = True)
     readCal.section = 2
-        
+
     def writeMem(self, blockNum, data, writeCal=False):
         """
         Name: U3.writeMem(blockNum, data, writeCal=False)
-        
+
         Args: blockNum, which block to write
               data, a list of bytes to write.
               writeCal, set to True to write to calibration instead
-        
+
         Desc: Writes 1 block (32 bytes) from the non-volatile user or
               calibration memory. Please read section 5.2.7 of the user's guide
               before you do something you may regret. Memory must be erased
               before writing.
-        
+
         Note: Do not call this function while streaming.
         """
         if not isinstance(data, list):
             raise LabJackException("Data must be a list of bytes")
-        
+
         command = [ 0 ] * 40
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x11
@@ -858,44 +858,44 @@ class U3(Device):
         command[6] = 0x00
         command[7] = blockNum
         command[8:] = data
-        
-        
+
+
         self._writeRead(command, 8, [0xF8, 0x01, command[3]])
     writeMem.section = 2
-    
+
     def writeCal(self, blockNum, data):
         """
         Name: U3.writeCal(blockNum, data)
-        
+
         Args: blockNum, which block to write
               data, a list of bytes
-        
+
         Desc: See the description of writeMem and section 5.2.7 of the user's
               guide.
-        
+
         Note: Do not call this function while streaming.
         """
         return self.writeMem(blockNum, data, writeCal = True)
     writeCal.section = 2
-    
+
     def eraseMem(self, eraseCal=False):
         """
         Name: U3.eraseMem(eraseCal=False)
-        
+
         Args: eraseCal, set to True to erase the calibration memory instead
-        
+
         Desc: The U3 uses flash memory that must be erased before writing.
               Please read section 5.2.8 of the user's guide before you do
               something you may regret.
-        
+
         Note: Do not call this function while streaming.
         """
         if not isinstance(eraseCal, bool):
             raise LabJackException("eraseCal must be a Boolean value (True or False).")
-        
+
         if eraseCal:
             command = [ 0 ] * 8
-            
+
             #command[0] = Checksum8
             command[1] = 0xF8
             command[2] = 0x01
@@ -906,53 +906,53 @@ class U3(Device):
             command[7] = 0x6C
         else:
             command = [ 0 ] * 6
-            
+
             #command[0] = Checksum8
             command[1] = 0xF8
             command[2] = 0x00
             command[3] = 0x29
             #command[4] = Checksum16 (LSB)
             #command[5] = Checksum16 (MSB)
-        
+
         self._writeRead(command, 8, [0xF8, 0x01, command[3]])
     eraseMem.section = 2
-    
+
     def eraseCal(self):
         """
         Name: U3.eraseCal()
-        
+
         Args: None
-        
+
         Desc: See the description of writeMem and section 5.2.8 of the user's
               guide.
-        
+
         Note: Do not call this function while streaming.
         """
         return self.eraseMem(eraseCal = True)
     eraseCal.section = 2
-    
+
     def reset(self, hardReset = False):
         """
         Name: U3.reset(hardReset = False)
-        
+
         Args: hardReset, set to True for a hard reset.
-        
-        Desc: Causes a soft or hard reset.  A soft reset consists of 
+
+        Desc: Causes a soft or hard reset.  A soft reset consists of
               re-initializing most variables without re-enumeration. A hard
               reset is a reboot of the processor and does cause re-enumeration.
               See section 5.2.9 of the User's guide.
         """
         command = [ 0 ] * 4
-        
+
         #command[0] = Checksum8
         command[1] = 0x99
         command[2] = 1
         if hardReset:
             command[2] = 2
         command[3] = 0x00
-        
+
         command = setChecksum8(command, 4)
-        
+
         self._writeRead(command, 4, [], False, False, False)
     reset.section = 2
 
@@ -989,7 +989,7 @@ class U3(Device):
                                frequency and the name is confusing.
 
         Desc: Stream mode operates on a table of channels that are scanned
-              at the specified scan rate. Before starting a stream, you need 
+              at the specified scan rate. Before starting a stream, you need
               to call this function to configure the table and scan clock.
 
         Note: Requires U3 hardware version 1.21 or greater.
@@ -1136,13 +1136,13 @@ class U3(Device):
         Name: U3.watchdog(ResetOnTimeout = False, SetDIOStateOnTimeout = False,
                           TimeoutPeriod = 60, DIOState = 0, DIONumber = 0,
                           onlyRead = False)
-        
+
         Args: Check out section 5.2.14 of the user's guide.
               Set onlyRead to True to perform only a read
-        
+
         Desc: This function will write the configuration of the watchdog,
               unless onlyRead is set to True.
-        
+
         Returns a dictionary:
         {
             'WatchDogEnabled' : True if the watchdog is enabled, otherwise False
@@ -1152,11 +1152,11 @@ class U3(Device):
             'DIOState' : The state the DIO will be set to on timeout
             'DIONumber' : Which DIO will be set on timeout
         }
-        
+
         NOTE: Requires U3 hardware version 1.21 or greater.
         """
         command = [ 0 ] * 16
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x05
@@ -1165,49 +1165,49 @@ class U3(Device):
         #command[5] = Checksum16 (MSB)
         if not onlyRead:
             command[6] = 1
-        
+
         if ResetOnTimeout:
             command[7] |= 1 << 5
         if SetDIOStateOnTimeout:
             command[7] |= 1 << 4
-        
+
         t = pack("<H", TimeoutPeriod)
         command[8] = ord(t[0])
         command[9] = ord(t[1])
-        
+
         command[10] = (( DIOState & 1 ) << 7) + ( DIONumber & 15)
-        
-        
+
+
         result = self._writeRead(command, 16, [0xF8, 0x05, 0x09])
-        
+
         watchdogStatus = {}
-        
+
         if result[7] == 0 or result[7] == 255:
             watchdogStatus['WatchDogEnabled'] = False
             watchdogStatus['ResetOnTimeout'] = False
             watchdogStatus['SetDIOStateOnTimeout'] = False
         else:
             watchdogStatus['WatchDogEnabled'] = True
-            
+
             if (result[7] >> 5) & 1:
                 watchdogStatus['ResetOnTimeout'] = True
             else:
                 watchdogStatus['ResetOnTimeout'] = False
-                
+
             if (result[7] >> 4) & 1:
                 watchdogStatus['SetDIOStateOnTimeout'] = True
             else:
                 watchdogStatus['SetDIOStateOnTimeout'] = False
-        
+
         watchdogStatus['TimeoutPeriod'] = unpack('<H', pack("BB", *result[8:10]))
-        
+
         if (result[10] >> 7) & 1:
             watchdogStatus['DIOState'] = 1
         else:
-            watchdogStatus['DIOState'] = 0 
-        
+            watchdogStatus['DIOState'] = 0
+
         watchdogStatus['DIONumber'] = ( result[10] & 15 )
-        
+
         return watchdogStatus
     watchdog.section = 2
 
@@ -1216,10 +1216,10 @@ class U3(Device):
         Name: U3.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
                      SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 4,
                      CLKPinNum = 5, MISOPinNum = 6, MOSIPinNum = 7)
-        
+
         Args: SPIBytes, a list of bytes to be transferred.
               See Section 5.2.15 of the user's guide.
-        
+
         Desc: Sends and receives serial data using SPI synchronous
               communication.
 
@@ -1236,34 +1236,34 @@ class U3(Device):
             CSPinNum = CSPINNum
 
         numSPIBytes = len(SPIBytes)
-        
+
         oddPacket = False
         if numSPIBytes%2 != 0:
             SPIBytes.append(0)
             numSPIBytes = numSPIBytes + 1
             oddPacket = True
-        
+
         command = [ 0 ] * (13 + numSPIBytes)
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 4 + (numSPIBytes//2)
         command[3] = 0x3A
         #command[4] = Checksum16 (LSB)
         #command[5] = Checksum16 (MSB)
-        
+
         if AutoCS:
             command[6] |= (1 << 7)
         if DisableDirConfig:
             command[6] |= (1 << 6)
-        
+
         spiModes = ('A', 'B', 'C', 'D')
         try:
             modeIndex = spiModes.index(SPIMode)
         except ValueError:
             raise LabJackException("Invalid SPIMode %r, valid modes are: %r" % (SPIMode, spiModes))
         command[6] |= modeIndex
-        
+
         command[7] = SPIClockFactor
         #command[8] = Reserved
         command[9] = CSPinNum
@@ -1273,11 +1273,11 @@ class U3(Device):
         command[13] = numSPIBytes
         if oddPacket:
             command[13] = numSPIBytes - 1
-        
+
         command[14:] = SPIBytes
-        
+
         result = self._writeRead(command, 8+numSPIBytes, [ 0xF8, 1+(numSPIBytes/2), 0x3A ])
-        
+
         if result[6] != 0:
             raise LowlevelErrorException(result[6], "The spi command returned an error:\n    %s" % lowlevelErrorToString(result[6]))
 
@@ -1287,30 +1287,30 @@ class U3(Device):
 
     def asynchConfig(self, Update = True, UARTEnable = True, DesiredBaud = 9600, olderHardware = False, configurePins = True):
         """
-        Name: U3.asynchConfig(Update = True, UARTEnable = True, 
+        Name: U3.asynchConfig(Update = True, UARTEnable = True,
                               DesiredBaud = 9600, olderHardware = False,
                               configurePins = True)
         Args: See section 5.2.16 of the User's Guide.
-              olderHardware, If using hardware 1.21, please set olderHardware 
+              olderHardware, If using hardware 1.21, please set olderHardware
                              to True and read the timer configuration first.
               configurePins, Will call the configIO to set up pins for you.
-        
-        Desc: Configures the U3 UART for asynchronous communication. 
-        
+
+        Desc: Configures the U3 UART for asynchronous communication.
+
         returns a dictionary:
         {
             'Update' : True means new parameters were written
             'UARTEnable' : True means the UART is enabled
             'BaudFactor' : The baud factor being used
         }
-        
+
         Note: Requires U3 hardware version 1.21+.
         """
         if configurePins:
             self.configIO(EnableUART=True)
-        
+
         command = [ 0 ] * 10
-            
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
@@ -1318,12 +1318,12 @@ class U3(Device):
         #command[4] = Checksum16 (LSB)
         #command[5] = Checksum16 (MSB)
         #command[6] = 0x00
-        
+
         if Update:
             command[7] |= ( 1 << 7 )
         if UARTEnable:
             command[7] |= ( 1 << 6 )
-        
+
         #command[8] = Reserved
         if olderHardware:
             command[9] = (2**8) - self.timerClockBase//DesiredBaud
@@ -1332,24 +1332,24 @@ class U3(Device):
             t = pack("<H", BaudFactor)
             command[8] = ord(t[0])
             command[9] = ord(t[1])
-        
+
         if olderHardware:
             result = self._writeRead(command, 10, [0xF8, 0x02, 0x14])
         else:
             result = self._writeRead(command, 10, [0xF8, 0x02, 0x14])
-        
+
         returnDict = {}
-        
+
         if (result[7] >> 7) & 1:
             returnDict['Update'] = True
         else:
             returnDict['Update'] = False
-        
+
         if (result[7] >> 6) & 1:
             returnDict['UARTEnable'] = True
         else:
             returnDict['UARTEnable'] = False
-            
+
         if olderHardware:
             returnDict['BaudFactor'] = result[9]
         else:
@@ -1357,38 +1357,38 @@ class U3(Device):
 
         return returnDict
     asynchConfig.section = 2
-    
+
     def asynchTX(self, AsynchBytes):
         """
         Name: U3.asynchTX(AsynchBytes)
-        
+
         Args: AsynchBytes, must be a list of bytes to transfer.
-        
+
         Desc: Sends bytes to the U3 UART which will be sent asynchronously on
               the transmit line. See section 5.2.17 of the user's guide.
-        
+
         returns a dictionary:
         {
             'NumAsynchBytesSent' : Number of Asynch Bytes Sent
             'NumAsynchBytesInRXBuffer' : How many bytes are currently in the
                                          RX buffer.
         }
-        
+
         Note: Requres U3 hardware version 1.21 or greater.
         """
         if not isinstance(AsynchBytes, list):
             raise LabJackException("AsynchBytes must be a list")
-        
+
         numBytes = len(AsynchBytes)
-        
+
         oddPacket = False
         if numBytes%2 != 0:
             AsynchBytes.append(0)
             numBytes = numBytes+1
             oddPacket = True
-        
+
         command = [ 0 ] * ( 8 + numBytes)
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 1 + ( numBytes//2 )
@@ -1399,20 +1399,20 @@ class U3(Device):
         command[7] = numBytes
         if oddPacket:
             command[7] = numBytes - 1
-        
+
         command[8:] = AsynchBytes
-        
+
         result = self._writeRead(command, 10, [0xF8, 0x02, 0x15])
-        
+
         return { 'NumAsynchBytesSent' : result[7], 'NumAsynchBytesInRXBuffer' : result[8] }
     asynchTX.section = 2
-    
+
     def asynchRX(self, Flush = False):
         """
         Name: U3.asynchRX(Flush = False)
-        
+
         Args: Flush, Set to True to flush
-        
+
         Desc: Reads the oldest 32 bytes from the U3 UART RX buffer
               (received on receive terminal). The buffer holds 256 bytes. See
               section 5.2.18 of the User's Guide.
@@ -1427,7 +1427,7 @@ class U3(Device):
         Note: Requres U3 hardware version 1.21 or greater.
         """
         command = [ 0 ] * 8
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
@@ -1437,45 +1437,45 @@ class U3(Device):
         #command[6] = 0x00
         if Flush:
             command[7] = 1
-        
-        
+
+
         result = self._writeRead(command, 40, [0xF8, 0x11, 0x16])
-        
+
         return { 'AsynchBytes' : result[8:], 'NumAsynchBytesInRXBuffer' : result[7] }
     asynchRX.section = 2
-    
+
     def i2c(self, Address, I2CBytes, EnableClockStretching = False, NoStopWhenRestarting = False, ResetAtStart = False, SpeedAdjust = 0, SDAPinNum = 6, SCLPinNum = 7, NumI2CBytesToReceive = 0, AddressByte = None):
         """
-        Name: U3.i2c(Address, I2CBytes, ResetAtStart = False, 
+        Name: U3.i2c(Address, I2CBytes, ResetAtStart = False,
                      EnableClockStretching = False, SpeedAdjust = 0,
                      SDAPinNum = 6, SCLPinNum = 7, NumI2CBytesToReceive = 0,
                      AddressByte = None)
-        
+
         Args: Address, the address (not shifted over)
               I2CBytes, must be a list of bytes to send.
               See section 5.2.19 of the user's guide.
               AddressByte, use this if you don't want a shift applied.
-                           This address will be put it in the low-level 
+                           This address will be put it in the low-level
                            packet directly and overrides Address. Optional.
-        
+
         Desc: Sends and receives serial data using I2C synchronous
               communication.
-        
+
         Note: Requires hardware version 1.21 or greater.
         """
         if not isinstance(I2CBytes, list):
             raise LabJackException("I2CBytes must be a list")
-        
+
         numBytes = len(I2CBytes)
-        
+
         oddPacket = False
         if numBytes%2 != 0:
             I2CBytes.append(0)
             numBytes = numBytes + 1
             oddPacket = True
-        
+
         command = [ 0 ] * (14 + numBytes)
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 4 + (numBytes//2)
@@ -1488,7 +1488,7 @@ class U3(Device):
             command[6] |= (1 << 2)
         if EnableClockStretching:
             command[6] |= (1 << 3)
-        
+
         command[7] = SpeedAdjust
         command[8] = SDAPinNum
         command[9] = SCLPinNum
@@ -1501,14 +1501,14 @@ class U3(Device):
             command[12] = numBytes-1
         command[13] = NumI2CBytesToReceive
         command[14:] = I2CBytes
-        
+
         oddResponse = False
         if NumI2CBytesToReceive%2 != 0:
             NumI2CBytesToReceive = NumI2CBytesToReceive+1
             oddResponse = True
-        
+
         result = self._writeRead(command, 12+NumI2CBytesToReceive, [0xF8, (3+(NumI2CBytesToReceive/2)), 0x3B])
-                
+
         if len(result) > 12:
             if oddResponse:
                 return { 'AckArray' : result[8:12], 'I2CBytes' : result[12:-1] }
@@ -1517,14 +1517,14 @@ class U3(Device):
         else:
             return { 'AckArray' : result[8:], 'I2CBytes' : [] }
     i2c.section = 2
-    
+
     def sht1x(self, DataPinNum = 4, ClockPinNum = 5, SHTOptions = 0xc0):
         """
         Name: U3.sht1x(DataPinNum = 4, ClockPinNum = 5, SHTOptions = 0xc0)
-        
+
         Args: See section 5.2.20 of the user's guide.
               SHTOptions, see below.
-        
+
         Desc: Reads temperature and humidity from a Sensirion SHT1X sensor
               (which is used by the EI-1050).
 
@@ -1539,7 +1539,7 @@ class U3(Device):
         }
 
         Note: Requires hardware version 1.21 or greater.
-        
+
         SHTOptions (and proof people read documentation):
             bit 7 = Read Temperature
             bit 6 = Read Realtive Humidity
@@ -1548,7 +1548,7 @@ class U3(Device):
             bit 0 = Resolution. 1 = 8 bit RH, 12 bit T; 0 = 12 RH, 14 bit T
         """
         command = [ 0 ] * 10
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
@@ -1559,35 +1559,35 @@ class U3(Device):
         command[7] = ClockPinNum
         #command[8] = Reserved
         command[9] = SHTOptions
-        
+
         result = self._writeRead(command, 16, [0xF8, 0x05, 0x39])
-        
+
         val = (result[11]*256) + result[10]
         temp = -39.60 + 0.01*val
-        
+
         val = (result[14]*256) + result[13]
         humid = -4 + 0.0405*val + -.0000028*(val*val)
         humid = (temp - 25)*(0.01 + 0.00008*val) + humid
-        
+
         return { 'StatusReg' : result[8], 'StatusRegCRC' : result[9], 'Temperature' : temp, 'TemperatureCRC' : result[12] , 'Humidity' : humid, 'HumidityCRC' : result[15] }
     sht1x.section = 2
-    
+
     def binaryToCalibratedAnalogVoltage(self, bits, isLowVoltage = True, isSingleEnded = True, isSpecialSetting = False, channelNumber = 0):
         """
         Name: U3.binaryToCalibratedAnalogVoltage(bits, isLowVoltage = True,
                                                  isSingleEnded = True,
                                                  isSpecialSetting = False,
                                                  channelNumber = 0)
-        
+
         Args: bits, the binary value of the reading.
               isLowVoltage, True if the reading came from a low-voltage channel
               isSingleEnded, True if the reading is not differential
               isSpecialSetting, True if the reading came from special range
               channelNumber, used to apply the correct calibration for HV
-        
+
         Desc: Converts the bits returned from AIN functions into a calibrated
               voltage.
-              
+
         Example:
         >>> import u3
         >>> d = u3.U3()
@@ -1624,7 +1624,7 @@ class U3(Device):
                 if hasCal:
                     hvSlope = self.calData['hvAIN%sSlope' % channelNumber]
                     hvOffset = self.calData['hvAIN%sOffset' % channelNumber]
-                    
+
                     diffR = ( bits * self.calData['lvDiffSlope'] ) + self.calData['lvDiffOffset'] + self.calData['vRefAtCAl']
                     reading = diffR * hvSlope / self.calData['lvSESlope'] + hvOffset
                     return reading
@@ -1633,31 +1633,31 @@ class U3(Device):
             else:
                 raise Exception("Can't do differential on high voltage channels")
     binaryToCalibratedAnalogVoltage.section = 3
-    
+
     def binaryToCalibratedAnalogTemperature(self, bytesTemperature):
         hasCal = self.calData is not None
-        
+
         if hasCal:
             return self.calData['tempSlope'] * float(bytesTemperature)
         else:
             return float(bytesTemperature) * 0.013021
-    
+
     def voltageToDACBits(self, volts, dacNumber = 0, is16Bits = False):
         """
         Name: U3.voltageToDACBits(volts, dacNumber = 0, is16Bits = False)
-        
+
         Args: volts, the voltage you would like to set the DAC to.
               dacNumber, 0 or 1, helps apply the correct calibration
               is16Bits, True if you are going to use the 16-bit DAC command
-        
-        Desc: Takes a voltage, and turns it into the bits needed for the DAC 
+
+        Desc: Takes a voltage, and turns it into the bits needed for the DAC
               Feedback commands.
         """
         if self.calData is not None:
             bits = ( volts * self.calData['dac%sSlope' % dacNumber] ) + self.calData['dac%sOffset' % dacNumber]
         else:
             bits = volts * 51.717
-        
+
         if is16Bits:
             bits = min(bits*256, 0xFFFF)
         else:
@@ -1665,52 +1665,52 @@ class U3(Device):
 
         return int(max(bits, 0))
     voltageToDACBits.section = 3
-    
+
     def getCalibrationData(self):
         """
         Name: U3.getCalibrationData()
-        
+
         Args: None
-        
+
         Desc: Reads in the U3's calibrations, so they can be applied to
               readings. Section 2.6.2 of the User's Guide is helpful. Sets up
-              an internal calData dict for any future calls that need 
+              an internal calData dict for any future calls that need
               calibration.
         """
         self.calData = dict()
-        
+
         calData = self.readCal(0)
-        
+
         self.calData['lvSESlope'] = toDouble(calData[0:8])
         self.calData['lvSEOffset'] = toDouble(calData[8:16])
         self.calData['lvDiffSlope'] = toDouble(calData[16:24])
         self.calData['lvDiffOffset'] = toDouble(calData[24:32])
-        
+
         calData = self.readCal(1)
-        
+
         self.calData['dac0Slope'] = toDouble(calData[0:8])
         self.calData['dac0Offset'] = toDouble(calData[8:16])
         self.calData['dac1Slope'] = toDouble(calData[16:24])
         self.calData['dac1Offset'] = toDouble(calData[24:32])
-        
+
         calData = self.readCal(2)
-        
+
         self.calData['tempSlope'] = toDouble(calData[0:8])
         self.calData['vRefAtCAl'] = toDouble(calData[8:16])
         self.calData['vRef1.5AtCal'] = toDouble(calData[16:24])
         self.calData['vRegAtCal'] = toDouble(calData[24:32])
-        
+
         try:
             #these blocks do not exist on hardware revisions < 1.30
             calData = self.readCal(3)
-        
+
             self.calData['hvAIN0Slope'] = toDouble(calData[0:8])
             self.calData['hvAIN1Slope'] = toDouble(calData[8:16])
             self.calData['hvAIN2Slope'] = toDouble(calData[16:24])
             self.calData['hvAIN3Slope'] = toDouble(calData[24:32])
-            
+
             calData = self.readCal(4)
-            
+
             self.calData['hvAIN0Offset'] = toDouble(calData[0:8])
             self.calData['hvAIN1Offset'] = toDouble(calData[8:16])
             self.calData['hvAIN2Offset'] = toDouble(calData[16:24])
@@ -1723,215 +1723,215 @@ class U3(Device):
 
         return self.calData
     getCalibrationData.section = 3
-    
+
     def readDefaultsConfig(self):
         """
-        Name: U3.readDefaultsConfig( ) 
+        Name: U3.readDefaultsConfig( )
         Args: None
         Desc: Reads the power-up defaults stored in flash.
         """
         results = dict()
         defaults = self.readDefaults(0)
-        
+
         results['FIODirection'] = defaults[4]
         results['FIOState'] = defaults[5]
         results['FIOAnalog'] = defaults[6]
-        
+
         results['EIODirection'] = defaults[8]
         results['EIOState'] = defaults[9]
         results['EIOAnalog'] = defaults[10]
-        
+
         results['CIODirection'] = defaults[12]
         results['CIOState'] = defaults[13]
-        
+
         results['NumOfTimersEnable'] = defaults[17]
         results['CounterMask'] = defaults[18]
         results['PinOffset'] = defaults[19]
         results['Options'] = defaults[20]
-        
+
         defaults = self.readDefaults(1)
         results['ClockSource'] = defaults[0]
         results['Divisor'] = defaults[1]
-        
+
         results['TMR0Mode'] = defaults[16]
         results['TMR0ValueL'] = defaults[17]
         results['TMR0ValueH'] = defaults[18]
-        
+
         results['TMR1Mode'] = defaults[20]
         results['TMR1ValueL'] = defaults[21]
         results['TMR1ValueH'] = defaults[22]
-        
+
         defaults = self.readDefaults(2)
-        
+
         results['DAC0'] = unpack( "<H", pack("BB", *defaults[16:18]) )[0]
-        
+
         results['DAC1'] = unpack( "<H", pack("BB", *defaults[20:22]) )[0]
-        
+
         defaults = self.readDefaults(3)
-        
+
         for i in range(16):
             results["AIN%sNegChannel" % i] = defaults[i]
-        
-        return results 
+
+        return results
     readDefaultsConfig.section = 3
-    
+
     def exportConfig(self):
         """
-        Name: U3.exportConfig( ) 
+        Name: U3.exportConfig( )
         Args: None
         Desc: Takes the current configuration and puts it into a ConfigParser
               object. Useful for saving the setup of your U3.
         """
         # Make a new configuration file
         parser = ConfigParser.SafeConfigParser()
-        
+
         # Change optionxform so that options preserve their case.
         parser.optionxform = str
-        
+
         # Local Id and name
         self.configU3()
-        
+
         section = "Identifiers"
         parser.add_section(section)
         parser.set(section, "Local ID", str(self.localId))
         parser.set(section, "Name", str(self.getName()))
         parser.set(section, "Device Type", str(self.devType))
-        
+
         # FIO Direction / State
         section = "FIOs"
         parser.add_section(section)
-        
+
         dirs, states = self.getFeedback( PortDirRead(), PortStateRead() )
-        
+
         parser.set(section, "FIOs Analog", str( self.readRegister(50590) ))
         parser.set(section, "EIOs Analog", str( self.readRegister(50591) ))
-        
+
         for key, value in dirs.items():
             parser.set(section, "%s Directions" % key, str(value))
-            
+
         for key, value in states.items():
             parser.set(section, "%s States" % key, str(value))
-            
+
         # DACs
         section = "DACs"
         parser.add_section(section)
-        
+
         dac0 = self.readRegister(5000)
         dac0 = max(dac0, 0)
         dac0 = min(dac0, 5)
         parser.set(section, "DAC0", "%0.2f" % dac0)
-        
+
         dac1 = self.readRegister(5002)
         dac1 = max(dac1, 0)
         dac1 = min(dac1, 5)
         parser.set(section, "DAC1", "%0.2f" % dac1)
-        
+
         # Timer Clock Configuration
         section = "Timer Clock Speed Configuration"
         parser.add_section(section)
-        
+
         timerclockconfig = self.configTimerClock()
         for key, value in timerclockconfig.items():
             parser.set(section, key, str(value))
-        
+
         # Timers / Counters
         section = "Timers And Counters"
         parser.add_section(section)
-        
+
         timerCounterConfig = self.configIO()
-        
+
         nte = timerCounterConfig['NumberOfTimersEnabled']
         ec0 = timerCounterConfig['EnableCounter0']
         ec1 = timerCounterConfig['EnableCounter1']
         cpo = timerCounterConfig['TimerCounterPinOffset']
-        
+
         parser.set(section, "NumberTimersEnabled", str(nte) )
         parser.set(section, "Counter0Enabled", str(ec0) )
         parser.set(section, "Counter1Enabled", str(ec1) )
         parser.set(section, "TimerCounterPinOffset", str(cpo) )
-        
+
         for i in range(nte):
             mode, value = self.readRegister(7100 + (2*i), numReg = 2, format = ">HH")
             parser.set(section, "Timer%i Mode" % i, str(mode))
             parser.set(section, "Timer%i Value" % i, str(value))
-        
-        
+
+
         return parser
     exportConfig.section = 3
 
     def loadConfig(self, configParserObj):
         """
-        Name: U3.loadConfig( configParserObj ) 
+        Name: U3.loadConfig( configParserObj )
         Args: configParserObj, A Config Parser object to load in
         Desc: Takes a configuration and updates the U3 to match it.
         """
         parser = configParserObj
-        
+
         # Set Identifiers:
         section = "Identifiers"
         if parser.has_section(section):
             if parser.has_option(section, "device type"):
                 if parser.getint(section, "device type") != self.devType:
                     raise Exception("Not a U3 Config file.")
-            
+
             if parser.has_option(section, "local id"):
                 self.configU3( LocalID = parser.getint(section, "local id"))
-                
+
             if parser.has_option(section, "name"):
                 self.setName( parser.get(section, "name") )
-            
+
         # Set FIOs:
         section = "FIOs"
         if parser.has_section(section):
             fioanalog = 0
             eioanalog = 0
-        
+
             fiodirs = 0
             eiodirs = 0
             ciodirs = 0
-            
+
             fiostates = 0
             eiostates = 0
             ciostates = 0
-            
+
             if parser.has_option(section, "fios analog"):
                 fioanalog = parser.getint(section, "fios analog")
             if parser.has_option(section, "eios analog"):
                 eioanalog = parser.getint(section, "eios analog")
-            
+
             if parser.has_option(section, "fios directions"):
                 fiodirs = parser.getint(section, "fios directions")
             if parser.has_option(section, "eios directions"):
                 eiodirs = parser.getint(section, "eios directions")
             if parser.has_option(section, "cios directions"):
                 ciodirs = parser.getint(section, "cios directions")
-            
+
             if parser.has_option(section, "fios states"):
                 fiostates = parser.getint(section, "fios states")
             if parser.has_option(section, "eios states"):
                 eiostates = parser.getint(section, "eios states")
             if parser.has_option(section, "cios states"):
                 ciostates = parser.getint(section, "cios states")
-            
+
             self.configIO(FIOAnalog = fioanalog, EIOAnalog = eioanalog)
-            
+
             self.getFeedback( PortStateWrite([fiostates, eiostates, ciostates]), PortDirWrite([fiodirs, eiodirs, ciodirs]) )
-                
+
         # Set DACs:
         section = "DACs"
         if parser.has_section(section):
             if parser.has_option(section, "dac0"):
                 self.writeRegister(5000, parser.getfloat(section, "dac0"))
-            
+
             if parser.has_option(section, "dac1"):
                 self.writeRegister(5002, parser.getfloat(section, "dac1"))
-                
+
         # Set Timer Clock Configuration
         section = "Timer Clock Speed Configuration"
         if parser.has_section(section):
             if parser.has_option(section, "timerclockbase") and parser.has_option(section, "timerclockdivisor"):
                 self.configTimerClock(TimerClockBase = parser.getint(section, "timerclockbase"), TimerClockDivisor = parser.getint(section, "timerclockdivisor"))
-        
+
         # Set Timers / Counters
         section = "Timers And Counters"
         if parser.has_section(section):
@@ -1939,41 +1939,41 @@ class U3(Device):
             c0e = None
             c1e = None
             cpo = None
-            
+
             if parser.has_option(section, "NumberTimersEnabled"):
                 nte = parser.getint(section, "NumberTimersEnabled")
-            
+
             if parser.has_option(section, "TimerCounterPinOffset"):
                 cpo = parser.getint(section, "TimerCounterPinOffset")
-            
+
             if parser.has_option(section, "Counter0Enabled"):
                 c0e = parser.getboolean(section, "Counter0Enabled")
-            
+
             if parser.has_option(section, "Counter1Enabled"):
                 c1e = parser.getboolean(section, "Counter1Enabled")
-                
+
             self.configIO(NumberOfTimersEnabled = nte, EnableCounter1 = c1e, EnableCounter0 = c0e, TimerCounterPinOffset = cpo)
-            
-            
+
+
             mode = None
             value = None
-            
+
             if parser.has_option(section, "timer0 mode"):
                 mode = parser.getint(section, "timer0 mode")
-                
+
                 if parser.has_option(section, "timer0 value"):
                     value = parser.getint(section, "timer0 value")
-                
+
                 self.getFeedback( Timer0Config(mode, value) )
-            
+
             if parser.has_option(section, "timer1 mode"):
                 mode = parser.getint(section, "timer1 mode")
-                
+
                 if parser.has_option(section, "timer1 value"):
                     value = parser.getint(section, "timer1 value")
-                
+
                 self.getFeedback( Timer1Config(mode, value) )
-    loadConfig.section = 3      
+    loadConfig.section = 3
 
 class FeedbackCommand(object):
     """
@@ -1987,7 +1987,7 @@ class AIN(FeedbackCommand):
     '''
     Analog Input Feedback command
 
-    specify the positive and negative channels to use 
+    specify the positive and negative channels to use
     (0-16, 30 and 31 are possible)
     also specify whether to turn on longSettle or quick Sample
 
@@ -2001,25 +2001,25 @@ class AIN(FeedbackCommand):
     Response:  [0xab, 0xf8, 0x3, 0x0, 0xaf, 0x0, 0x0, 0x0, 0x0, 0x20, 0x8f, 0x0]
     [36640]
     '''
-    def __init__(self, PositiveChannel, NegativeChannel=31, 
+    def __init__(self, PositiveChannel, NegativeChannel=31,
             LongSettling=False, QuickSample=False):
         self.positiveChannel = PositiveChannel
         self.negativeChannel = NegativeChannel
         self.longSettling = LongSettling
         self.quickSample = QuickSample
-        
+
         validChannels = list(range(16)) + [30, 31]
         if PositiveChannel not in validChannels:
             raise Exception("Invalid Positive Channel specified")
         if NegativeChannel not in validChannels:
             raise Exception("Invalid Negative Channel specified")
-        b = PositiveChannel 
+        b = PositiveChannel
         b |= (int(bool(LongSettling)) << 6)
         b |= (int(bool(QuickSample)) << 7)
         self.cmdBytes = [ 0x01, b, NegativeChannel ]
 
     readLen =  2
-    
+
     def __repr__(self):
         return "<u3.AIN( PositiveChannel = %s, NegativeChannel = %s, LongSettling = %s, QuickSample = %s )>" % ( self.positiveChannel, self.negativeChannel, self.longSettling, self.quickSample )
 
@@ -2051,9 +2051,9 @@ class WaitShort(FeedbackCommand):
 class WaitLong(FeedbackCommand):
     '''
     WaitLong Feedback command
-    
+
     specify the number of 32ms time increments to wait
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2065,7 +2065,7 @@ class WaitLong(FeedbackCommand):
     def __init__(self, Time):
         self.time = Time % 256
         self.cmdBytes = [ 6, Time % 256 ]
-        
+
     def __repr__(self):
         return "<u3.WaitLong( Time = %s )>" % self.time
 
@@ -2074,7 +2074,7 @@ class LED(FeedbackCommand):
     LED Toggle
 
     specify whether the LED should be on or off by truth value
-    
+
     1 or True = On, 0 or False = Off
 
     >>> import u3
@@ -2092,7 +2092,7 @@ class LED(FeedbackCommand):
     def __init__(self, State):
         self.state = State
         self.cmdBytes = [ 9, int(bool(State)) ]
-        
+
     def __repr__(self):
         return "<u3.LED( State = %s )>" % self.state
 
@@ -2105,7 +2105,7 @@ class BitStateRead(FeedbackCommand):
 
     IONumber: 0-7=FIO, 8-15=EIO, 16-19=CIO
     return 0 or 1
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2130,7 +2130,7 @@ class BitStateWrite(FeedbackCommand):
     '''
     BitStateWrite Feedback command
 
-    write a single bit of digital I/O.  The direction of the 
+    write a single bit of digital I/O.  The direction of the
     specified line is forced to output.
 
     IONumber: 0-7=FIO, 8-15=EIO, 16-19=CIO
@@ -2148,7 +2148,7 @@ class BitStateWrite(FeedbackCommand):
         self.ioNumber = IONumber
         self.state = State
         self.cmdBytes = [ 11, (IONumber % 20) + (int(bool(State)) << 7) ]
-        
+
     def __repr__(self):
         return "<u3.BitStateWrite( IONumber = %s, State = %s )>" % (self.ioNumber, self.state)
 
@@ -2187,7 +2187,7 @@ class BitDirWrite(FeedbackCommand):
 
     IONumber: 0-7=FIO, 8-15=EIO, 16-19=CIO
     Direction: 1 = Output, 0 = Input
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2200,10 +2200,10 @@ class BitDirWrite(FeedbackCommand):
         self.ioNumber = IONumber
         self.direction = Direction
         self.cmdBytes = [ 13, (IONumber % 20) + (int(bool(Direction)) << 7) ]
-        
+
     def __repr__(self):
         return "<u3.BitDirWrite( IONumber = %s, Direction = %s )>" % (self.ioNumber, self.direction)
-    
+
 class PortStateRead(FeedbackCommand):
     """
     PortStateRead Feedback command
@@ -2219,19 +2219,19 @@ class PortStateRead(FeedbackCommand):
     """
     def __init__(self):
         self.cmdBytes = [ 26 ]
-        
+
     readLen = 3
-    
+
     def handle(self, input):
         return {'FIO' : input[0], 'EIO' : input[1], 'CIO' : input[2] }
-    
+
     def __repr__(self):
         return "<u3.PortStateRead()>"
 
 class PortStateWrite(FeedbackCommand):
     """
     PortStateWrite Feedback command
-    
+
     State: A list of 3 bytes representing FIO, EIO, CIO
     WriteMask: A list of 3 bytes, representing which to update.
                The Default is all ones.
@@ -2246,17 +2246,17 @@ class PortStateWrite(FeedbackCommand):
     """
     def __init__(self, State, WriteMask = [0xff, 0xff, 0xff]):
         self.state = State
-        self.writeMask = WriteMask 
+        self.writeMask = WriteMask
         self.cmdBytes = [ 27 ] + WriteMask + State
-        
+
     def __repr__(self):
         return "<u3.PortStateWrite( State = %s, WriteMask = %s )>" % (self.state, self.writeMask)
-        
+
 class PortDirRead(FeedbackCommand):
     """
     PortDirRead Feedback command
     Reads the direction of all digital I/O.
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2267,19 +2267,19 @@ class PortDirRead(FeedbackCommand):
     """
     def __init__(self):
         self.cmdBytes = [ 28 ]
-        
+
     readLen = 3
-    
+
     def __repr__(self):
         return "<u3.PortDirRead()>"
-    
+
     def handle(self, input):
         return {'FIO' : input[0], 'EIO' : input[1], 'CIO' : input[2] }
 
 class PortDirWrite(FeedbackCommand):
     """
     PortDirWrite Feedback command
-    
+
     Direction: A list of 3 bytes representing FIO, EIO, CIO
     WriteMask: A list of 3 bytes, representing which to update. Default is all ones.
 
@@ -2303,12 +2303,12 @@ class PortDirWrite(FeedbackCommand):
 class DAC8(FeedbackCommand):
     '''
     8-bit DAC Feedback command
-    
+
     Controls a single analog output
 
     Dac: 0 or 1
     Value: 0-255
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2319,20 +2319,20 @@ class DAC8(FeedbackCommand):
     '''
     def __init__(self, Dac, Value):
         self.dac = Dac
-        self.value = Value % 256 
+        self.value = Value % 256
         self.cmdBytes = [ 34 + (Dac % 2), Value % 256 ]
-    
+
     def __repr__(self):
         return "<u3.DAC8( Dac = %s, Value = %s )>" % (self.dac, self.value)
-        
+
 class DAC0_8(DAC8):
     """
     8-bit DAC Feedback command for DAC0
-    
+
     Controls DAC0 in 8-bit mode.
 
     Value: 0-255
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2343,18 +2343,18 @@ class DAC0_8(DAC8):
     """
     def __init__(self, Value):
         DAC8.__init__(self, 0, Value)
-        
+
     def __repr__(self):
         return "<u3.DAC0_8( Value = %s )>" % self.value
 
 class DAC1_8(DAC8):
     """
     8-bit DAC Feedback command for DAC1
-    
+
     Controls DAC1 in 8-bit mode.
 
     Value: 0-255
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2365,7 +2365,7 @@ class DAC1_8(DAC8):
     """
     def __init__(self, Value):
         DAC8.__init__(self, 1, Value)
-        
+
     def __repr__(self):
         return "<u3.DAC1_8( Value = %s )>" % self.value
 
@@ -2377,7 +2377,7 @@ class DAC16(FeedbackCommand):
 
     Dac: 0 or 1
     Value: 0-65535
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2390,18 +2390,18 @@ class DAC16(FeedbackCommand):
         self.dac = Dac
         self.value = Value
         self.cmdBytes = [ 38 + (Dac % 2), Value % 256, Value >> 8 ]
-        
+
     def __repr__(self):
         return "<u3.DAC16( Dac = %s, Value = %s )>" % (self.dac, self.value)
 
 class DAC0_16(DAC16):
     """
     16-bit DAC Feedback command for DAC0
-    
+
     Controls DAC0 in 16-bit mode.
 
     Value: 0-65535
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2412,18 +2412,18 @@ class DAC0_16(DAC16):
     """
     def __init__(self, Value):
         DAC16.__init__(self, 0, Value)
-        
+
     def __repr__(self):
         return "<u3.DAC0_16( Value = %s )>" % self.value
 
 class DAC1_16(DAC16):
     """
     16-bit DAC Feedback command for DAC1
-    
+
     Controls DAC1 in 16-bit mode.
 
     Value: 0-65535
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2434,7 +2434,7 @@ class DAC1_16(DAC16):
     """
     def __init__(self, Value):
         DAC16.__init__(self, 1, Value)
-    
+
     def __repr__(self):
         return "<u3.DAC1_16( Value = %s )>" % self.value
 
@@ -2443,20 +2443,20 @@ class Timer(FeedbackCommand):
     For reading the value of the Timer. It provides the ability to update/reset
     a given timer, and read the timer value.
     (Section 5.2.5.14 of the User's Guide)
-    
+
     timer: Either 0 or 1 for timer 0 or timer 1
-     
+
     UpdateReset: Set True if you want to update the value
-    
+
     Value: Only updated if the UpdateReset bit is 1.  The meaning of this
            parameter varies with the timer mode.
-           
+
     Mode: Set to the timer mode to handle any special processing. See classes
           QuadratureInputTimer and TimerStopInput1.
 
     Returns an unsigned integer of the timer value, unless Mode has been
     specified and there are special return values. See Section 2.9.1 for
-    expected return values. 
+    expected return values.
 
     >>> import u3
     >>> d = u3.U3()
@@ -2479,15 +2479,15 @@ class Timer(FeedbackCommand):
             raise LabJackException("Timer should be either 0 or 1.")
         if UpdateReset and (Value is None):
             raise LabJackException("UpdateReset set but no value.")
-            
-        
+
+
         self.cmdBytes = [ (42 + (2*timer)), UpdateReset, Value % 256, Value >> 8 ]
-    
+
     readLen = 4
-    
+
     def __repr__(self):
         return "<u3.Timer( timer = %s, UpdateReset = %s, Value = %s, Mode = %s )>" % (self.timer, self.updateReset, self.value, self.mode)
-    
+
     def handle(self, input):
         inStr = pack('B' * len(input), *input)
         if self.mode == 8:
@@ -2503,12 +2503,12 @@ class Timer0(Timer):
     For reading the value of the Timer0. It provides the ability to
     update/reset Timer0, and read the timer value.
     (Section 5.2.5.14 of the User's Guide)
-     
+
     UpdateReset: Set True if you want to update the value
-    
+
     Value: Only updated if the UpdateReset bit is 1.  The meaning of this
            parameter varies with the timer mode.
-           
+
     Mode: Set to the timer mode to handle any special processing. See classes
           QuadratureInputTimer and TimerStopInput1.
 
@@ -2526,7 +2526,7 @@ class Timer0(Timer):
     """
     def __init__(self, UpdateReset = False, Value = 0, Mode = None):
         Timer.__init__(self, 0, UpdateReset, Value, Mode)
-        
+
     def __repr__(self):
         return "<u3.Timer0( UpdateReset = %s, Value = %s, Mode = %s )>" % (self.updateReset, self.value, self.mode)
 
@@ -2535,9 +2535,9 @@ class Timer1(Timer):
     For reading the value of the Timer1. It provides the ability to
     update/reset Timer1, and read the timer value.
     (Section 5.2.5.14 of the User's Guide)
-     
+
     UpdateReset: Set True if you want to update the value
-    
+
     Value: Only updated if the UpdateReset bit is 1.  The meaning of this
            parameter varies with the timer mode.
 
@@ -2558,7 +2558,7 @@ class Timer1(Timer):
     """
     def __init__(self, UpdateReset = False, Value = 0, Mode = None):
         Timer.__init__(self, 1, UpdateReset, Value, Mode)
-        
+
     def __repr__(self):
         return "<u3.Timer1( UpdateReset = %s, Value = %s, Mode = %s )>" % (self.updateReset, self.value, self.mode)
 
@@ -2566,15 +2566,15 @@ class QuadratureInputTimer(Timer):
     """
     For reading Quadrature input timers. They are special because their values
     are signed.
-    
+
     (Section 2.9.1.8 of the User's Guide)
-    
+
     Args:
        UpdateReset: Set True if you want to reset the counter.
        Value: Set to 0, and UpdateReset to True to reset the counter.
-    
+
     Returns a signed integer.
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2600,7 +2600,7 @@ class QuadratureInputTimer(Timer):
     """
     def __init__(self, UpdateReset = False, Value = 0):
         Timer.__init__(self, 0, UpdateReset, Value, Mode = 8)
-        
+
     def __repr__(self):
         return "<u3.QuadratureInputTimer( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)
 
@@ -2608,16 +2608,16 @@ class TimerStopInput1(Timer1):
     """
     For reading a stop input timer. They are special because the value returns
     the current edge count and the stop value.
-    
+
     (Section 2.9.1.9 of the User's Guide)
-    
+
     Args:
         UpdateReset: Set True if you want to update the value.
         Value: The stop value. Only updated if the UpdateReset bit is 1.
-    
+
     Returns a tuple where the first value is current edge count, and the second
     value is the stop value.
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2644,11 +2644,11 @@ class TimerStopInput1(Timer1):
 class TimerConfig(FeedbackCommand):
     """
     This IOType configures a particular timer.
-    
+
     timer = # of the timer to configure
-    
+
     TimerMode = See Section 2.9 for more information about the available modes.
-    
+
     Value = The meaning of this parameter varies with the timer mode.
 
     >>> import u3
@@ -2672,27 +2672,27 @@ class TimerConfig(FeedbackCommand):
         #Conditions come from pages 33-34 of user's guide
         if timer != 0 and timer != 1:
             raise LabJackException("Timer should be either 0 or 1.")
-        
+
         if TimerMode > 14 or TimerMode < 0:
             raise LabJackException("Invalid Timer Mode.")
-        
+
         self.timer = timer
         self.timerMode = TimerMode
         self.value = Value
-        
+
         self.cmdBytes = [43 + (timer * 2), TimerMode, Value % 256, Value >> 8]
-        
+
     def __repr__(self):
         return "<u3.TimerConfig( timer = %s, TimerMode = %s, Value = %s )>" % (self.timer, self.timerMode, self.value)
 
 class Timer0Config(TimerConfig):
     """
     This IOType configures Timer0.
-    
+
     TimerMode = See Section 2.9 for more information about the available modes.
-    
+
     Value = The meaning of this parameter varies with the timer mode.
-    
+
     >>> import u3
     >>> d = u3.U3()
     >>> d.debug = True
@@ -2711,16 +2711,16 @@ class Timer0Config(TimerConfig):
     """
     def __init__(self, TimerMode, Value = 0):
         TimerConfig.__init__(self, 0, TimerMode, Value)
-        
+
     def __repr__(self):
         return "<u3.Timer0Config( TimerMode = %s, Value = %s )>" % (self.timerMode, self.value)
 
 class Timer1Config(TimerConfig):
     """
     This IOType configures Timer1.
-    
+
     TimerMode = See Section 2.9 for more information about the available modes.
-    
+
     Value = The meaning of this parameter varies with the timer mode.
 
     >>> import u3
@@ -2737,7 +2737,7 @@ class Timer1Config(TimerConfig):
     """
     def __init__(self, TimerMode, Value = 0):
         TimerConfig.__init__(self, 1, TimerMode, Value)
-    
+
     def __repr__(self):
         return "<u3.Timer1Config( TimerMode = %s, Value = %s )>" % (self.timerMode, self.value)
 

--- a/src/u3.py
+++ b/src/u3.py
@@ -1438,7 +1438,6 @@ class U3(Device):
         if Flush:
             command[7] = 1
 
-
         result = self._writeRead(command, 40, [0xF8, 0x11, 0x16])
 
         return {'AsynchBytes': result[8:], 'NumAsynchBytesInRXBuffer': result[7]}
@@ -1855,7 +1854,6 @@ class U3(Device):
             parser.set(section, "Timer%i Mode" % i, str(mode))
             parser.set(section, "Timer%i Value" % i, str(value))
 
-
         return parser
     exportConfig.section = 3
 
@@ -1954,7 +1952,6 @@ class U3(Device):
 
             self.configIO(NumberOfTimersEnabled=nte, EnableCounter1=c1e, EnableCounter0=c0e, TimerCounterPinOffset=cpo)
 
-
             mode = None
             value = None
 
@@ -1975,6 +1972,7 @@ class U3(Device):
                 self.getFeedback(Timer1Config(mode, value))
     loadConfig.section = 3
 
+
 class FeedbackCommand(object):
     """
     The FeedbackCommand class is the base for all the Feedback commands.
@@ -1982,6 +1980,7 @@ class FeedbackCommand(object):
     readLen = 0
     def handle(self, input):
         return None
+
 
 class AIN(FeedbackCommand):
     '''
@@ -2027,6 +2026,7 @@ class AIN(FeedbackCommand):
         result = (input[1] << 8) + input[0]
         return result
 
+
 class WaitShort(FeedbackCommand):
     '''
     WaitShort Feedback command
@@ -2048,6 +2048,7 @@ class WaitShort(FeedbackCommand):
     def __repr__(self):
         return "<u3.WaitShort( Time = %s )>" % self.time
 
+
 class WaitLong(FeedbackCommand):
     '''
     WaitLong Feedback command
@@ -2068,6 +2069,7 @@ class WaitLong(FeedbackCommand):
 
     def __repr__(self):
         return "<u3.WaitLong( Time = %s )>" % self.time
+
 
 class LED(FeedbackCommand):
     '''
@@ -2095,6 +2097,7 @@ class LED(FeedbackCommand):
 
     def __repr__(self):
         return "<u3.LED( State = %s )>" % self.state
+
 
 class BitStateRead(FeedbackCommand):
     '''
@@ -2126,6 +2129,7 @@ class BitStateRead(FeedbackCommand):
     def handle(self, input):
         return int(bool(input[0]))
 
+
 class BitStateWrite(FeedbackCommand):
     '''
     BitStateWrite Feedback command
@@ -2151,6 +2155,7 @@ class BitStateWrite(FeedbackCommand):
 
     def __repr__(self):
         return "<u3.BitStateWrite( IONumber = %s, State = %s )>" % (self.ioNumber, self.state)
+
 
 class BitDirRead(FeedbackCommand):
     '''
@@ -2179,6 +2184,7 @@ class BitDirRead(FeedbackCommand):
     def handle(self, input):
         return int(bool(input[0]))
 
+
 class BitDirWrite(FeedbackCommand):
     '''
     BitDirWrite Feedback command
@@ -2204,6 +2210,7 @@ class BitDirWrite(FeedbackCommand):
     def __repr__(self):
         return "<u3.BitDirWrite( IONumber = %s, Direction = %s )>" % (self.ioNumber, self.direction)
 
+
 class PortStateRead(FeedbackCommand):
     """
     PortStateRead Feedback command
@@ -2227,6 +2234,7 @@ class PortStateRead(FeedbackCommand):
 
     def __repr__(self):
         return "<u3.PortStateRead()>"
+
 
 class PortStateWrite(FeedbackCommand):
     """
@@ -2252,6 +2260,7 @@ class PortStateWrite(FeedbackCommand):
     def __repr__(self):
         return "<u3.PortStateWrite( State = %s, WriteMask = %s )>" % (self.state, self.writeMask)
 
+
 class PortDirRead(FeedbackCommand):
     """
     PortDirRead Feedback command
@@ -2276,6 +2285,7 @@ class PortDirRead(FeedbackCommand):
     def handle(self, input):
         return {'FIO': input[0], 'EIO': input[1], 'CIO': input[2]}
 
+
 class PortDirWrite(FeedbackCommand):
     """
     PortDirWrite Feedback command
@@ -2299,6 +2309,7 @@ class PortDirWrite(FeedbackCommand):
 
     def __repr__(self):
         return "<u3.PortDirWrite( Direction = %s, WriteMask = %s )>" % (self.direction, self.writeMask)
+
 
 class DAC8(FeedbackCommand):
     '''
@@ -2325,6 +2336,7 @@ class DAC8(FeedbackCommand):
     def __repr__(self):
         return "<u3.DAC8( Dac = %s, Value = %s )>" % (self.dac, self.value)
 
+
 class DAC0_8(DAC8):
     """
     8-bit DAC Feedback command for DAC0
@@ -2347,6 +2359,7 @@ class DAC0_8(DAC8):
     def __repr__(self):
         return "<u3.DAC0_8( Value = %s )>" % self.value
 
+
 class DAC1_8(DAC8):
     """
     8-bit DAC Feedback command for DAC1
@@ -2368,6 +2381,7 @@ class DAC1_8(DAC8):
 
     def __repr__(self):
         return "<u3.DAC1_8( Value = %s )>" % self.value
+
 
 class DAC16(FeedbackCommand):
     '''
@@ -2394,6 +2408,7 @@ class DAC16(FeedbackCommand):
     def __repr__(self):
         return "<u3.DAC16( Dac = %s, Value = %s )>" % (self.dac, self.value)
 
+
 class DAC0_16(DAC16):
     """
     16-bit DAC Feedback command for DAC0
@@ -2416,6 +2431,7 @@ class DAC0_16(DAC16):
     def __repr__(self):
         return "<u3.DAC0_16( Value = %s )>" % self.value
 
+
 class DAC1_16(DAC16):
     """
     16-bit DAC Feedback command for DAC1
@@ -2437,6 +2453,7 @@ class DAC1_16(DAC16):
 
     def __repr__(self):
         return "<u3.DAC1_16( Value = %s )>" % self.value
+
 
 class Timer(FeedbackCommand):
     """
@@ -2480,7 +2497,6 @@ class Timer(FeedbackCommand):
         if UpdateReset and (Value is None):
             raise LabJackException("UpdateReset set but no value.")
 
-
         self.cmdBytes = [(42 + (2 * timer)), UpdateReset, Value % 256, Value >> 8]
 
     readLen = 4
@@ -2497,6 +2513,7 @@ class Timer(FeedbackCommand):
             return current, maxCount
         else:
             return unpack('<I', inStr)[0]
+
 
 class Timer0(Timer):
     """
@@ -2530,6 +2547,7 @@ class Timer0(Timer):
     def __repr__(self):
         return "<u3.Timer0( UpdateReset = %s, Value = %s, Mode = %s )>" % (self.updateReset, self.value, self.mode)
 
+
 class Timer1(Timer):
     """
     For reading the value of the Timer1. It provides the ability to
@@ -2561,6 +2579,7 @@ class Timer1(Timer):
 
     def __repr__(self):
         return "<u3.Timer1( UpdateReset = %s, Value = %s, Mode = %s )>" % (self.updateReset, self.value, self.mode)
+
 
 class QuadratureInputTimer(Timer):
     """
@@ -2604,6 +2623,7 @@ class QuadratureInputTimer(Timer):
     def __repr__(self):
         return "<u3.QuadratureInputTimer( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)
 
+
 class TimerStopInput1(Timer1):
     """
     For reading a stop input timer. They are special because the value returns
@@ -2640,6 +2660,7 @@ class TimerStopInput1(Timer1):
 
     def __repr__(self):
         return "<u3.TimerStopInput1( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)
+
 
 class TimerConfig(FeedbackCommand):
     """
@@ -2685,6 +2706,7 @@ class TimerConfig(FeedbackCommand):
     def __repr__(self):
         return "<u3.TimerConfig( timer = %s, TimerMode = %s, Value = %s )>" % (self.timer, self.timerMode, self.value)
 
+
 class Timer0Config(TimerConfig):
     """
     This IOType configures Timer0.
@@ -2714,6 +2736,7 @@ class Timer0Config(TimerConfig):
 
     def __repr__(self):
         return "<u3.Timer0Config( TimerMode = %s, Value = %s )>" % (self.timerMode, self.value)
+
 
 class Timer1Config(TimerConfig):
     """

--- a/src/u3.py
+++ b/src/u3.py
@@ -22,7 +22,7 @@ import warnings
 
 try:
     import ConfigParser
-except ImportError: # Python 3
+except ImportError:  # Python 3
     import configparser as ConfigParser
 
 from struct import pack, unpack
@@ -40,8 +40,8 @@ from LabJackPython import (
 
 
 FIO0, FIO1, FIO2, FIO3, FIO4, FIO5, FIO6, FIO7, \
-EIO0, EIO1, EIO2, EIO3, EIO4, EIO5, EIO6, EIO7, \
-CIO0, CIO1, CIO2, CIO3 = range(20)
+    EIO0, EIO1, EIO2, EIO3, EIO4, EIO5, EIO6, EIO7, \
+    CIO0, CIO1, CIO2, CIO3 = range(20)
 
 
 def openAllU3():
@@ -53,7 +53,7 @@ def openAllU3():
     returnDict = dict()
 
     for i in range(deviceCount(3)):
-        d = U3(firstFound = False, devNumber = i+1)
+        d = U3(firstFound=False, devNumber=i + 1)
         returnDict[str(d.serialNumber)] = d
 
     return returnDict
@@ -69,7 +69,7 @@ class U3(Device):
     >>> print(d.configU3())
     {'SerialNumber': 320032102, ... , 'FirmwareVersion': '1.26'}
     """
-    def __init__(self, debug = False, autoOpen = True, **kargs):
+    def __init__(self, debug=False, autoOpen=True, **kargs):
         """
         Name: U3.__init__(debug = False, autoOpen = True, **openArgs)
 
@@ -93,7 +93,7 @@ class U3(Device):
         >>> import u3
         >>> d = u3.U3(localId = 2)
         """
-        Device.__init__(self, None, devType = 3)
+        Device.__init__(self, None, devType=3)
         self.debug = debug
         self.calData = None
         self.ledState = True
@@ -102,7 +102,7 @@ class U3(Device):
             self.open(**kargs)
     __init__.section = 1
 
-    def open(self, firstFound = True, serial = None, localId = None, devNumber = None, handleOnly = False, LJSocket = None):
+    def open(self, firstFound=True, serial=None, localId=None, devNumber=None, handleOnly=False, LJSocket=None):
         """
         Name: U3.open(firstFound = True, localId = None, devNumber = None,
                       handleOnly = False, LJSocket = None)
@@ -134,10 +134,10 @@ class U3(Device):
         >>> d = u3.U3(autoOpen = False)
         >>> d.open(LJSocket = "localhost:6000")
         """
-        Device.open(self, 3, firstFound = firstFound, serial = serial, localId = localId, devNumber = devNumber, handleOnly = handleOnly, LJSocket = LJSocket )
+        Device.open(self, 3, firstFound=firstFound, serial=serial, localId=localId, devNumber=devNumber, handleOnly=handleOnly, LJSocket=LJSocket)
     open.section = 1
 
-    def configU3(self, LocalID = None, TimerCounterConfig = None, FIOAnalog = None, FIODirection = None, FIOState = None, EIOAnalog = None, EIODirection = None, EIOState = None, CIODirection = None, CIOState = None, DAC1Enable = None, DAC0 = None, DAC1 = None, TimerClockConfig = None, TimerClockDivisor = None, CompatibilityOptions = None):
+    def configU3(self, LocalID=None, TimerCounterConfig=None, FIOAnalog=None, FIODirection=None, FIOState=None, EIOAnalog=None, EIODirection=None, EIOState=None, CIODirection=None, CIOState=None, DAC1Enable=None, DAC0=None, DAC1=None, TimerClockConfig=None, TimerClockDivisor=None, CompatibilityOptions=None):
         """
         Name: U3.configU3(LocalID = None, TimerCounterConfig = None, FIOAnalog = None, FIODirection = None, FIOState = None, EIOAnalog = None, EIODirection = None, EIOState = None, CIODirection = None, CIOState = None, DAC1Enable = None, DAC0 = None, DAC1 = None, TimerClockConfig = None, TimerClockDivisor = None, CompatibilityOptions = None)
 
@@ -190,16 +190,16 @@ class U3(Device):
         if CompatibilityOptions is not None:
             writeMask |= 32
 
-        command = [ 0 ] * 26
+        command = [0] * 26
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x0A
         command[3] = 0x08
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = writeMask
-        #command[7] = WriteMask1
+        # command[7] = WriteMask1
 
         if LocalID is not None:
             command[8] = LocalID
@@ -290,7 +290,7 @@ class U3(Device):
         return {'FirmwareVersion': self.firmwareVersion, 'BootloaderVersion': self.bootloaderVersion, 'HardwareVersion': self.hardwareVersion, 'SerialNumber': self.serialNumber, 'ProductID': self.productId, 'LocalID': self.localId, 'TimerCounterMask': self.timerCounterMask, 'FIOAnalog': self.fioAnalog, 'FIODirection': self.fioDirection, 'FIOState': self.fioState, 'EIOAnalog': self.eioAnalog, 'EIODirection': self.eioDirection, 'EIOState': self.eioState, 'CIODirection': self.cioDirection, 'CIOState': self.cioState, 'DAC1Enable': self.dac1Enable, 'DAC0': self.dac0, 'DAC1': self.dac1, 'TimerClockConfig': self.timerClockConfig, 'TimerClockDivisor': self.timerClockDivisor, 'CompatibilityOptions': self.compatibilityOptions, 'VersionInfo': self.versionInfo, 'DeviceName': self.deviceName}
     configU3.section = 2
 
-    def configIO(self, TimerCounterPinOffset = None, EnableCounter1 = None, EnableCounter0 = None, NumberOfTimersEnabled = None, FIOAnalog = None, EIOAnalog = None, EnableUART = None):
+    def configIO(self, TimerCounterPinOffset=None, EnableCounter1=None, EnableCounter0=None, NumberOfTimersEnabled=None, FIOAnalog=None, EIOAnalog=None, EnableUART=None):
         """
         Name: U3.configIO(TimerCounterPinOffset = 4, EnableCounter1 = None, EnableCounter0 = None, NumberOfTimersEnabled = None, FIOAnalog = None, EIOAnalog = None, EnableUART = None)
 
@@ -345,35 +345,35 @@ class U3(Device):
             writeMask |= 1
             writeMask |= (1 << 5)
 
-        if TimerCounterPinOffset is not None or EnableCounter1 is not None or EnableCounter0 is not None or NumberOfTimersEnabled is not None :
+        if TimerCounterPinOffset is not None or EnableCounter1 is not None or EnableCounter0 is not None or NumberOfTimersEnabled is not None:
             writeMask |= 1
 
-        command = [ 0 ] * 12
+        command = [0] * 12
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x03
         command[3] = 0x0B
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = writeMask
-        #command[7] = Reserved
+        # command[7] = Reserved
         command[8] = 0
 
         if EnableUART is not None:
             command[9] = int(EnableUART) << 2
 
         if TimerCounterPinOffset is None:
-            command[8] |= ( 4 & 15 ) << 4
+            command[8] |= (4 & 15) << 4
         else:
-            command[8] |= ( TimerCounterPinOffset & 15 ) << 4
+            command[8] |= (TimerCounterPinOffset & 15) << 4
 
         if EnableCounter1 is not None:
             command[8] |= 1 << 3
         if EnableCounter0 is not None:
             command[8] |= 1 << 2
         if NumberOfTimersEnabled is not None:
-            command[8] |= ( NumberOfTimersEnabled & 3 )
+            command[8] |= (NumberOfTimersEnabled & 3)
 
         if FIOAnalog is not None:
             command[10] = FIOAnalog
@@ -386,19 +386,19 @@ class U3(Device):
         self.timerCounterConfig = result[8]
 
         self.numberTimersEnabled = self.timerCounterConfig & 3
-        self.counter0Enabled = bool( (self.timerCounterConfig >> 2) & 1 )
-        self.counter1Enabled = bool( (self.timerCounterConfig >> 3) & 1 )
-        self.timerCounterPinOffset = ( self.timerCounterConfig >> 4 )
+        self.counter0Enabled = bool((self.timerCounterConfig >> 2) & 1)
+        self.counter1Enabled = bool((self.timerCounterConfig >> 3) & 1)
+        self.timerCounterPinOffset = (self.timerCounterConfig >> 4)
 
 
         self.dac1Enable = result[9]
         self.fioAnalog = result[10]
         self.eioAnalog = result[11]
 
-        return { 'TimerCounterConfig' : self.timerCounterConfig, 'DAC1Enable' : self.dac1Enable, 'FIOAnalog' : self.fioAnalog, 'EIOAnalog' : self.eioAnalog, 'NumberOfTimersEnabled' : self.numberTimersEnabled, 'EnableCounter0' : self.counter0Enabled, 'EnableCounter1' : self.counter1Enabled, 'TimerCounterPinOffset' : self.timerCounterPinOffset }
+        return {'TimerCounterConfig': self.timerCounterConfig, 'DAC1Enable': self.dac1Enable, 'FIOAnalog': self.fioAnalog, 'EIOAnalog': self.eioAnalog, 'NumberOfTimersEnabled': self.numberTimersEnabled, 'EnableCounter0': self.counter0Enabled, 'EnableCounter1': self.counter1Enabled, 'TimerCounterPinOffset': self.timerCounterPinOffset}
     configIO.section = 2
 
-    def configTimerClock(self, TimerClockBase = None, TimerClockDivisor = None):
+    def configTimerClock(self, TimerClockBase=None, TimerClockDivisor=None):
         """
         Name: U3.configTimerClock(TimerClockBase = None, TimerClockDivisor = None)
         Args: TimeClockBase, the base for the timer clock.
@@ -409,29 +409,29 @@ class U3(Device):
 
         Note: TimerClockBase and TimerClockDivisor must be set at the same time.
         """
-        command = [ 0 ] * 10
+        command = [0] * 10
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
         command[3] = 0x0A
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #command[6] = Reserved
-        #command[7] = Reserved
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # command[6] = Reserved
+        # command[7] = Reserved
         if TimerClockBase is not None:
-            command[8] = ( 1 << 7 ) + ( TimerClockBase & 7 )
+            command[8] = (1 << 7) + (TimerClockBase & 7)
             if TimerClockDivisor is not None:
-                command[9] =  TimerClockDivisor
+                command[9] = TimerClockDivisor
         elif TimerClockDivisor is not None:
             raise LabJackException("You can't set just the divisor, must set both.")
 
         result = self._writeRead(command, 10, [0xf8, 0x02, 0x0A])
 
-        self.timerClockBase = ( result[8] & 7 )
+        self.timerClockBase = (result[8] & 7)
         self.timerClockDivisor = result[9]
 
-        return { 'TimerClockBase' : self.timerClockBase, 'TimerClockDivisor' : self.timerClockDivisor }
+        return {'TimerClockBase': self.timerClockBase, 'TimerClockDivisor': self.timerClockDivisor}
     configTimerClock.section = 2
 
     def toggleLED(self):
@@ -447,11 +447,11 @@ class U3(Device):
         >>> d = u3.U3()
         >>> d.toggleLED()
         """
-        self.getFeedback( LED( not self.ledState ) )
+        self.getFeedback(LED(not self.ledState))
         self.ledState = not self.ledState
     toggleLED.section = 3
 
-    def setFIOState(self, fioNum, state = 1):
+    def setFIOState(self, fioNum, state=1):
         """
         Name: U3.setFIOState(fioNum, state = 1)
         Args: fioNum, which FIO to change
@@ -488,7 +488,7 @@ class U3(Device):
         return self.getFeedback(BitStateRead(fioNum))[0]
     getFIOState.section = 3
 
-    def setDOState(self, ioNum, state = 1):
+    def setDOState(self, ioNum, state=1):
         """
         Name: U3.setDOState(ioNum, state = 1)
         Args: ioNum, which digital I/O to change
@@ -559,11 +559,11 @@ class U3(Device):
         if self.calData is None:
             self.getCalibrationData()
 
-        bits, = self.getFeedback( AIN(30, 31) )
+        bits, = self.getFeedback(AIN(30, 31))
 
         return self.binaryToCalibratedAnalogTemperature(bits)
 
-    def getAIN(self, posChannel, negChannel = 31, longSettle=False, quickSample=False):
+    def getAIN(self, posChannel, negChannel=31, longSettle=False, quickSample=False):
         """
         Name: U3.getAIN(posChannel, negChannel = 31, longSettle=False,
                                                      quickSample=False)
@@ -604,7 +604,7 @@ class U3(Device):
         if isSpecial:
             negChannel = 32
 
-        return self.binaryToCalibratedAnalogVoltage(bits, isLowVoltage = lvChannel, isSingleEnded = singleEnded, isSpecialSetting = isSpecial, channelNumber = posChannel)
+        return self.binaryToCalibratedAnalogVoltage(bits, isLowVoltage=lvChannel, isSingleEnded=singleEnded, isSpecialSetting=isSpecial, channelNumber=posChannel)
     getAIN.section = 3
 
     def configAnalog(self, *args):
@@ -641,8 +641,8 @@ class U3(Device):
             elif i < EIO0:
                 FIOAnalog |= 2**i
             else:
-                EIOAnalog |= 2**(i-EIO0)   # Start the EIO counting at 0, not 8
-        return self.configIO(FIOAnalog = FIOAnalog, EIOAnalog = EIOAnalog)
+                EIOAnalog |= 2**(i - EIO0)   # Start the EIO counting at 0, not 8
+        return self.configIO(FIOAnalog=FIOAnalog, EIOAnalog=EIOAnalog)
 
     def configDigital(self, *args):
         """
@@ -686,9 +686,9 @@ class U3(Device):
                 if FIOAnalog & 2**i:    # If it is set
                     FIOAnalog ^= 2**i   # Remove it
             else:
-                if EIOAnalog & 2**(i-EIO0):   # Start the EIO counting at 0, not 8
-                    EIOAnalog ^= 2**(i-EIO0)
-        return self.configIO(FIOAnalog = FIOAnalog, EIOAnalog = EIOAnalog)
+                if EIOAnalog & 2**(i - EIO0):   # Start the EIO counting at 0, not 8
+                    EIOAnalog ^= 2**(i - EIO0)
+        return self.configIO(FIOAnalog=FIOAnalog, EIOAnalog=EIOAnalog)
 
     def _buildBuffer(self, sendBuffer, readLen, commandlist):
         """
@@ -709,7 +709,7 @@ class U3(Device):
         """
         for cmd in commandlist:
             if isinstance(cmd, FeedbackCommand):
-                results.append(cmd.handle(rcvBuffer[i:i+cmd.readLen]))
+                results.append(cmd.handle(rcvBuffer[i:i + cmd.readLen]))
                 i += cmd.readLen
             elif isinstance(cmd, list):
                 self._buildFeedbackResults(rcvBuffer, cmd, results, i)
@@ -760,7 +760,7 @@ class U3(Device):
         if readLen > MAX_USB_PACKET_LENGTH:
             raise LabJackException("ERROR: The feedback command you are attempting to send would yield a response that is greater than 64 bytes ( %s bytes ). Break your commands up into separate calls to getFeedback()." % readLen)
 
-        rcvBuffer = self._writeRead(sendBuffer, readLen, [], checkBytes = False, stream = False, checksum = True)
+        rcvBuffer = self._writeRead(sendBuffer, readLen, [], checkBytes=False, stream=False, checksum=True)
 
         # Check the response for errors
         try:
@@ -770,11 +770,11 @@ class U3(Device):
                 raise LabJackException("Got incorrect command bytes")
         except LowlevelErrorException:
             if isinstance(commandlist[0], list):
-                culprit = commandlist[0][ (rcvBuffer[7] -1) ]
+                culprit = commandlist[0][(rcvBuffer[7] - 1)]
             else:
-                culprit = commandlist[ (rcvBuffer[7] -1) ]
+                culprit = commandlist[(rcvBuffer[7] - 1)]
 
-            raise LowlevelErrorException("\nThis Command\n    %s\nreturned an error:\n    %s" %  (culprit , lowlevelErrorToString(rcvBuffer[6])))
+            raise LowlevelErrorException("\nThis Command\n    %s\nreturned an error:\n    %s" % (culprit, lowlevelErrorToString(rcvBuffer[6])))
 
 
         results = []
@@ -795,16 +795,16 @@ class U3(Device):
 
         NOTE: Do not call this function while streaming.
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
         command[3] = 0x2A
         if readCal:
             command[3] = 0x2D
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = 0x00
         command[7] = blockNum
 
@@ -824,7 +824,7 @@ class U3(Device):
 
         Note: Do not call this function while streaming.
         """
-        return self.readMem(blockNum, readCal = True)
+        return self.readMem(blockNum, readCal=True)
     readCal.section = 2
 
     def writeMem(self, blockNum, data, writeCal=False):
@@ -845,16 +845,16 @@ class U3(Device):
         if not isinstance(data, list):
             raise LabJackException("Data must be a list of bytes")
 
-        command = [ 0 ] * 40
+        command = [0] * 40
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x11
         command[3] = 0x28
         if writeCal:
             command[3] = 0x2B
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = 0x00
         command[7] = blockNum
         command[8:] = data
@@ -875,7 +875,7 @@ class U3(Device):
 
         Note: Do not call this function while streaming.
         """
-        return self.writeMem(blockNum, data, writeCal = True)
+        return self.writeMem(blockNum, data, writeCal=True)
     writeCal.section = 2
 
     def eraseMem(self, eraseCal=False):
@@ -894,25 +894,25 @@ class U3(Device):
             raise LabJackException("eraseCal must be a Boolean value (True or False).")
 
         if eraseCal:
-            command = [ 0 ] * 8
+            command = [0] * 8
 
-            #command[0] = Checksum8
+            # command[0] = Checksum8
             command[1] = 0xF8
             command[2] = 0x01
             command[3] = 0x2C
-            #command[4] = Checksum16 (LSB)
-            #command[5] = Checksum16 (MSB)
+            # command[4] = Checksum16 (LSB)
+            # command[5] = Checksum16 (MSB)
             command[6] = 0x4C
             command[7] = 0x6C
         else:
-            command = [ 0 ] * 6
+            command = [0] * 6
 
-            #command[0] = Checksum8
+            # command[0] = Checksum8
             command[1] = 0xF8
             command[2] = 0x00
             command[3] = 0x29
-            #command[4] = Checksum16 (LSB)
-            #command[5] = Checksum16 (MSB)
+            # command[4] = Checksum16 (LSB)
+            # command[5] = Checksum16 (MSB)
 
         self._writeRead(command, 8, [0xF8, 0x01, command[3]])
     eraseMem.section = 2
@@ -928,10 +928,10 @@ class U3(Device):
 
         Note: Do not call this function while streaming.
         """
-        return self.eraseMem(eraseCal = True)
+        return self.eraseMem(eraseCal=True)
     eraseCal.section = 2
 
-    def reset(self, hardReset = False):
+    def reset(self, hardReset=False):
         """
         Name: U3.reset(hardReset = False)
 
@@ -942,9 +942,9 @@ class U3(Device):
               reset is a reboot of the processor and does cause re-enumeration.
               See section 5.2.9 of the User's guide.
         """
-        command = [ 0 ] * 4
+        command = [0] * 4
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0x99
         command[2] = 1
         if hardReset:
@@ -956,7 +956,7 @@ class U3(Device):
         self._writeRead(command, 4, [], False, False, False)
     reset.section = 2
 
-    def streamConfig(self, NumChannels = 1, SamplesPerPacket = 25, InternalStreamClockFrequency = 0, DivideClockBy256 = False, Resolution = 3, ScanInterval = 1, PChannels = [30], NChannels = [31], ScanFrequency = None, SampleFrequency = None):
+    def streamConfig(self, NumChannels=1, SamplesPerPacket=25, InternalStreamClockFrequency=0, DivideClockBy256=False, Resolution=3, ScanInterval=1, PChannels=[30], NChannels=[31], ScanFrequency=None, SampleFrequency=None):
         """
         Name: U3.streamConfig(NumChannels = 1, SamplesPerPacket = 25,
                               InternalStreamClockFrequency = 0, DivideClockBy256 = False,
@@ -1023,19 +1023,19 @@ class U3(Device):
         SamplesPerPacket = int(SamplesPerPacket)
         SamplesPerPacket = min(SamplesPerPacket, 25)
 
-        command = [0] * (12+(NumChannels*2))
+        command = [0] * (12 + (NumChannels * 2))
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = NumChannels + 3
         command[3] = 0x11
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = NumChannels
         command[7] = SamplesPerPacket
-        #command[8] = Reserved
+        # command[8] = Reserved
 
-        command[9] |= (InternalStreamClockFrequency&0x01) << 3
+        command[9] |= (InternalStreamClockFrequency & 0x01) << 3
         if DivideClockBy256:
             command[9] |= 1 << 2
         command[9] |= Resolution & 3
@@ -1044,11 +1044,11 @@ class U3(Device):
         command[11] = (ScanInterval >> 8) & 0xFF
 
         for i in range(NumChannels):
-            command[12+(i*2)] = PChannels[i]
+            command[12 + (i * 2)] = PChannels[i]
             if NChannels[i] == 32:
-                command[13+(i*2)] = 30
+                command[13 + (i * 2)] = 30
             else:
-                command[13+(i*2)] = NChannels[i]
+                command[13 + (i * 2)] = NChannels[i]
 
         self._writeRead(command, 8, [0xF8, 0x01, 0x11])
 
@@ -1065,17 +1065,17 @@ class U3(Device):
         if DivideClockBy256:
             freq /= 256
 
-        freq = freq/ScanInterval
+        freq = freq / ScanInterval
 
         if SamplesPerPacket < 25:
-            #limit to one packet
+            # limit to one packet
             self.packetsPerRequest = 1
         else:
-            self.packetsPerRequest = max(1, int(freq/SamplesPerPacket))
+            self.packetsPerRequest = max(1, int(freq / SamplesPerPacket))
             self.packetsPerRequest = min(self.packetsPerRequest, 48)
     streamConfig.section = 2
 
-    def processStreamData(self, result, numBytes = None):
+    def processStreamData(self, result, numBytes=None):
         """
         Name: U3.processStreamData(result, numBytes = None)
         Args: result, the string or bytes object returned from
@@ -1122,7 +1122,7 @@ class U3(Device):
                     if self.streamNegChannels[self.streamPacketOffset] == 32:
                         isSpecial = True
 
-                    value = self.binaryToCalibratedAnalogVoltage(value, isLowVoltage = lvChannel, isSingleEnded = singleEnded, channelNumber = self.streamChannelNumbers[self.streamPacketOffset], isSpecialSetting = isSpecial)
+                    value = self.binaryToCalibratedAnalogVoltage(value, isLowVoltage=lvChannel, isSingleEnded=singleEnded, channelNumber=self.streamChannelNumbers[self.streamPacketOffset], isSpecialSetting=isSpecial)
 
                 returnDict["AIN%s" % self.streamChannelNumbers[self.streamPacketOffset]].append(value)
 
@@ -1131,7 +1131,7 @@ class U3(Device):
         return returnDict
     processStreamData.section = 3
 
-    def watchdog(self, ResetOnTimeout = False, SetDIOStateOnTimeout = False, TimeoutPeriod = 60, DIOState = 0, DIONumber = 0, onlyRead=False):
+    def watchdog(self, ResetOnTimeout=False, SetDIOStateOnTimeout=False, TimeoutPeriod=60, DIOState=0, DIONumber=0, onlyRead=False):
         """
         Name: U3.watchdog(ResetOnTimeout = False, SetDIOStateOnTimeout = False,
                           TimeoutPeriod = 60, DIOState = 0, DIONumber = 0,
@@ -1155,14 +1155,14 @@ class U3(Device):
 
         NOTE: Requires U3 hardware version 1.21 or greater.
         """
-        command = [ 0 ] * 16
+        command = [0] * 16
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x05
         command[3] = 0x09
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         if not onlyRead:
             command[6] = 1
 
@@ -1175,7 +1175,7 @@ class U3(Device):
         command[8] = ord(t[0])
         command[9] = ord(t[1])
 
-        command[10] = (( DIOState & 1 ) << 7) + ( DIONumber & 15)
+        command[10] = ((DIOState & 1) << 7) + (DIONumber & 15)
 
 
         result = self._writeRead(command, 16, [0xF8, 0x05, 0x09])
@@ -1206,12 +1206,12 @@ class U3(Device):
         else:
             watchdogStatus['DIOState'] = 0
 
-        watchdogStatus['DIONumber'] = ( result[10] & 15 )
+        watchdogStatus['DIONumber'] = (result[10] & 15)
 
         return watchdogStatus
     watchdog.section = 2
 
-    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 4, CLKPinNum = 5, MISOPinNum = 6, MOSIPinNum = 7, CSPINNum = None):
+    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig=False, SPIMode='A', SPIClockFactor=0, CSPinNum=4, CLKPinNum=5, MISOPinNum=6, MOSIPinNum=7, CSPINNum=None):
         """
         Name: U3.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
                      SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 4,
@@ -1238,19 +1238,19 @@ class U3(Device):
         numSPIBytes = len(SPIBytes)
 
         oddPacket = False
-        if numSPIBytes%2 != 0:
+        if numSPIBytes % 2 != 0:
             SPIBytes.append(0)
             numSPIBytes = numSPIBytes + 1
             oddPacket = True
 
-        command = [ 0 ] * (13 + numSPIBytes)
+        command = [0] * (13 + numSPIBytes)
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 4 + (numSPIBytes//2)
+        command[2] = 4 + (numSPIBytes // 2)
         command[3] = 0x3A
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
 
         if AutoCS:
             command[6] |= (1 << 7)
@@ -1265,7 +1265,7 @@ class U3(Device):
         command[6] |= modeIndex
 
         command[7] = SPIClockFactor
-        #command[8] = Reserved
+        # command[8] = Reserved
         command[9] = CSPinNum
         command[10] = CLKPinNum
         command[11] = MISOPinNum
@@ -1276,16 +1276,16 @@ class U3(Device):
 
         command[14:] = SPIBytes
 
-        result = self._writeRead(command, 8+numSPIBytes, [ 0xF8, 1+(numSPIBytes/2), 0x3A ])
+        result = self._writeRead(command, 8 + numSPIBytes, [0xF8, 1 + (numSPIBytes / 2), 0x3A])
 
         if result[6] != 0:
             raise LowlevelErrorException(result[6], "The spi command returned an error:\n    %s" % lowlevelErrorToString(result[6]))
 
-        return { 'NumSPIBytesTransferred' : result[7], 'SPIBytes' : result[8:] }
+        return {'NumSPIBytesTransferred': result[7], 'SPIBytes': result[8:]}
 
     spi.section = 2
 
-    def asynchConfig(self, Update = True, UARTEnable = True, DesiredBaud = 9600, olderHardware = False, configurePins = True):
+    def asynchConfig(self, Update=True, UARTEnable=True, DesiredBaud=9600, olderHardware=False, configurePins=True):
         """
         Name: U3.asynchConfig(Update = True, UARTEnable = True,
                               DesiredBaud = 9600, olderHardware = False,
@@ -1309,26 +1309,26 @@ class U3(Device):
         if configurePins:
             self.configIO(EnableUART=True)
 
-        command = [ 0 ] * 10
+        command = [0] * 10
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
         command[3] = 0x14
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #command[6] = 0x00
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # command[6] = 0x00
 
         if Update:
-            command[7] |= ( 1 << 7 )
+            command[7] |= (1 << 7)
         if UARTEnable:
-            command[7] |= ( 1 << 6 )
+            command[7] |= (1 << 6)
 
-        #command[8] = Reserved
+        # command[8] = Reserved
         if olderHardware:
-            command[9] = (2**8) - self.timerClockBase//DesiredBaud
+            command[9] = (2**8) - self.timerClockBase // DesiredBaud
         else:
-            BaudFactor = (2**16) - 48000000//(2 * DesiredBaud)
+            BaudFactor = (2**16) - 48000000 // (2 * DesiredBaud)
             t = pack("<H", BaudFactor)
             command[8] = ord(t[0])
             command[9] = ord(t[1])
@@ -1382,20 +1382,20 @@ class U3(Device):
         numBytes = len(AsynchBytes)
 
         oddPacket = False
-        if numBytes%2 != 0:
+        if numBytes % 2 != 0:
             AsynchBytes.append(0)
-            numBytes = numBytes+1
+            numBytes = numBytes + 1
             oddPacket = True
 
-        command = [ 0 ] * ( 8 + numBytes)
+        command = [0] * (8 + numBytes)
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 1 + ( numBytes//2 )
+        command[2] = 1 + (numBytes // 2)
         command[3] = 0x15
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #command[6] = 0x00
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # command[6] = 0x00
         command[7] = numBytes
         if oddPacket:
             command[7] = numBytes - 1
@@ -1404,10 +1404,10 @@ class U3(Device):
 
         result = self._writeRead(command, 10, [0xF8, 0x02, 0x15])
 
-        return { 'NumAsynchBytesSent' : result[7], 'NumAsynchBytesInRXBuffer' : result[8] }
+        return {'NumAsynchBytesSent': result[7], 'NumAsynchBytesInRXBuffer': result[8]}
     asynchTX.section = 2
 
-    def asynchRX(self, Flush = False):
+    def asynchRX(self, Flush=False):
         """
         Name: U3.asynchRX(Flush = False)
 
@@ -1426,25 +1426,25 @@ class U3(Device):
 
         Note: Requres U3 hardware version 1.21 or greater.
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
         command[3] = 0x16
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #command[6] = 0x00
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # command[6] = 0x00
         if Flush:
             command[7] = 1
 
 
         result = self._writeRead(command, 40, [0xF8, 0x11, 0x16])
 
-        return { 'AsynchBytes' : result[8:], 'NumAsynchBytesInRXBuffer' : result[7] }
+        return {'AsynchBytes': result[8:], 'NumAsynchBytesInRXBuffer': result[7]}
     asynchRX.section = 2
 
-    def i2c(self, Address, I2CBytes, EnableClockStretching = False, NoStopWhenRestarting = False, ResetAtStart = False, SpeedAdjust = 0, SDAPinNum = 6, SCLPinNum = 7, NumI2CBytesToReceive = 0, AddressByte = None):
+    def i2c(self, Address, I2CBytes, EnableClockStretching=False, NoStopWhenRestarting=False, ResetAtStart=False, SpeedAdjust=0, SDAPinNum=6, SCLPinNum=7, NumI2CBytesToReceive=0, AddressByte=None):
         """
         Name: U3.i2c(Address, I2CBytes, ResetAtStart = False,
                      EnableClockStretching = False, SpeedAdjust = 0,
@@ -1469,19 +1469,19 @@ class U3(Device):
         numBytes = len(I2CBytes)
 
         oddPacket = False
-        if numBytes%2 != 0:
+        if numBytes % 2 != 0:
             I2CBytes.append(0)
             numBytes = numBytes + 1
             oddPacket = True
 
-        command = [ 0 ] * (14 + numBytes)
+        command = [0] * (14 + numBytes)
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 4 + (numBytes//2)
+        command[2] = 4 + (numBytes // 2)
         command[3] = 0x3B
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         if ResetAtStart:
             command[6] |= (1 << 1)
         if NoStopWhenRestarting:
@@ -1498,27 +1498,27 @@ class U3(Device):
             command[10] = Address << 1
         command[12] = numBytes
         if oddPacket:
-            command[12] = numBytes-1
+            command[12] = numBytes - 1
         command[13] = NumI2CBytesToReceive
         command[14:] = I2CBytes
 
         oddResponse = False
-        if NumI2CBytesToReceive%2 != 0:
-            NumI2CBytesToReceive = NumI2CBytesToReceive+1
+        if NumI2CBytesToReceive % 2 != 0:
+            NumI2CBytesToReceive = NumI2CBytesToReceive + 1
             oddResponse = True
 
-        result = self._writeRead(command, 12+NumI2CBytesToReceive, [0xF8, (3+(NumI2CBytesToReceive/2)), 0x3B])
+        result = self._writeRead(command, 12 + NumI2CBytesToReceive, [0xF8, (3 + (NumI2CBytesToReceive / 2)), 0x3B])
 
         if len(result) > 12:
             if oddResponse:
-                return { 'AckArray' : result[8:12], 'I2CBytes' : result[12:-1] }
+                return {'AckArray': result[8:12], 'I2CBytes': result[12:-1]}
             else:
-                return { 'AckArray' : result[8:12], 'I2CBytes' : result[12:] }
+                return {'AckArray': result[8:12], 'I2CBytes': result[12:]}
         else:
-            return { 'AckArray' : result[8:], 'I2CBytes' : [] }
+            return {'AckArray': result[8:], 'I2CBytes': []}
     i2c.section = 2
 
-    def sht1x(self, DataPinNum = 4, ClockPinNum = 5, SHTOptions = 0xc0):
+    def sht1x(self, DataPinNum=4, ClockPinNum=5, SHTOptions=0xc0):
         """
         Name: U3.sht1x(DataPinNum = 4, ClockPinNum = 5, SHTOptions = 0xc0)
 
@@ -1547,32 +1547,32 @@ class U3(Device):
             bit 1 = Reserved at 0
             bit 0 = Resolution. 1 = 8 bit RH, 12 bit T; 0 = 12 RH, 14 bit T
         """
-        command = [ 0 ] * 10
+        command = [0] * 10
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
         command[3] = 0x39
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = DataPinNum
         command[7] = ClockPinNum
-        #command[8] = Reserved
+        # command[8] = Reserved
         command[9] = SHTOptions
 
         result = self._writeRead(command, 16, [0xF8, 0x05, 0x39])
 
-        val = (result[11]*256) + result[10]
-        temp = -39.60 + 0.01*val
+        val = (result[11] * 256) + result[10]
+        temp = -39.60 + 0.01 * val
 
-        val = (result[14]*256) + result[13]
-        humid = -4 + 0.0405*val + -.0000028*(val*val)
-        humid = (temp - 25)*(0.01 + 0.00008*val) + humid
+        val = (result[14] * 256) + result[13]
+        humid = -4 + 0.0405 * val + -.0000028 * (val * val)
+        humid = (temp - 25) * (0.01 + 0.00008 * val) + humid
 
-        return { 'StatusReg' : result[8], 'StatusRegCRC' : result[9], 'Temperature' : temp, 'TemperatureCRC' : result[12] , 'Humidity' : humid, 'HumidityCRC' : result[15] }
+        return {'StatusReg': result[8], 'StatusRegCRC': result[9], 'Temperature': temp, 'TemperatureCRC': result[12], 'Humidity': humid, 'HumidityCRC': result[15]}
     sht1x.section = 2
 
-    def binaryToCalibratedAnalogVoltage(self, bits, isLowVoltage = True, isSingleEnded = True, isSpecialSetting = False, channelNumber = 0):
+    def binaryToCalibratedAnalogVoltage(self, bits, isLowVoltage=True, isSingleEnded=True, isSpecialSetting=False, channelNumber=0):
         """
         Name: U3.binaryToCalibratedAnalogVoltage(bits, isLowVoltage = True,
                                                  isSingleEnded = True,
@@ -1601,31 +1601,31 @@ class U3(Device):
         if isLowVoltage:
             if isSingleEnded and not isSpecialSetting:
                 if hasCal:
-                    return ( bits * self.calData['lvSESlope'] ) + self.calData['lvSEOffset']
+                    return (bits * self.calData['lvSESlope']) + self.calData['lvSEOffset']
                 else:
-                    return ( bits * 0.000037231 ) + 0
+                    return (bits * 0.000037231) + 0
             elif isSpecialSetting:
                 if hasCal:
-                    return ( bits * self.calData['lvDiffSlope'] ) + self.calData['lvDiffOffset'] + self.calData['vRefAtCAl']
+                    return (bits * self.calData['lvDiffSlope']) + self.calData['lvDiffOffset'] + self.calData['vRefAtCAl']
                 else:
                     return (bits * 0.000074463)
             else:
                 if hasCal:
-                    return ( bits * self.calData['lvDiffSlope'] ) + self.calData['lvDiffOffset']
+                    return (bits * self.calData['lvDiffSlope']) + self.calData['lvDiffOffset']
                 else:
                     return (bits * 0.000074463) - 2.44
         else:
             if isSingleEnded and not isSpecialSetting:
                 if hasCal:
-                    return ( bits * self.calData['hvAIN%sSlope' % channelNumber] ) + self.calData['hvAIN%sOffset' % channelNumber]
+                    return (bits * self.calData['hvAIN%sSlope' % channelNumber]) + self.calData['hvAIN%sOffset' % channelNumber]
                 else:
-                    return ( bits * 0.000314 ) + -10.3
+                    return (bits * 0.000314) + -10.3
             elif isSpecialSetting:
                 if hasCal:
                     hvSlope = self.calData['hvAIN%sSlope' % channelNumber]
                     hvOffset = self.calData['hvAIN%sOffset' % channelNumber]
 
-                    diffR = ( bits * self.calData['lvDiffSlope'] ) + self.calData['lvDiffOffset'] + self.calData['vRefAtCAl']
+                    diffR = (bits * self.calData['lvDiffSlope']) + self.calData['lvDiffOffset'] + self.calData['vRefAtCAl']
                     reading = diffR * hvSlope / self.calData['lvSESlope'] + hvOffset
                     return reading
                 else:
@@ -1642,7 +1642,7 @@ class U3(Device):
         else:
             return float(bytesTemperature) * 0.013021
 
-    def voltageToDACBits(self, volts, dacNumber = 0, is16Bits = False):
+    def voltageToDACBits(self, volts, dacNumber=0, is16Bits=False):
         """
         Name: U3.voltageToDACBits(volts, dacNumber = 0, is16Bits = False)
 
@@ -1654,12 +1654,12 @@ class U3(Device):
               Feedback commands.
         """
         if self.calData is not None:
-            bits = ( volts * self.calData['dac%sSlope' % dacNumber] ) + self.calData['dac%sOffset' % dacNumber]
+            bits = (volts * self.calData['dac%sSlope' % dacNumber]) + self.calData['dac%sOffset' % dacNumber]
         else:
             bits = volts * 51.717
 
         if is16Bits:
-            bits = min(bits*256, 0xFFFF)
+            bits = min(bits * 256, 0xFFFF)
         else:
             bits = min(bits, 0xFF)
 
@@ -1701,7 +1701,7 @@ class U3(Device):
         self.calData['vRegAtCal'] = toDouble(calData[24:32])
 
         try:
-            #these blocks do not exist on hardware revisions < 1.30
+            # these blocks do not exist on hardware revisions < 1.30
             calData = self.readCal(3)
 
             self.calData['hvAIN0Slope'] = toDouble(calData[0:8])
@@ -1718,7 +1718,7 @@ class U3(Device):
         except LowlevelErrorException:
             ex = sys.exc_info()[1]
             if ex.errorCode != 26:
-                #not an invalid block error, so do not disregard
+                # not an invalid block error, so do not disregard
                 raise ex
 
         return self.calData
@@ -1763,9 +1763,9 @@ class U3(Device):
 
         defaults = self.readDefaults(2)
 
-        results['DAC0'] = unpack( "<H", pack("BB", *defaults[16:18]) )[0]
+        results['DAC0'] = unpack("<H", pack("BB", *defaults[16:18]))[0]
 
-        results['DAC1'] = unpack( "<H", pack("BB", *defaults[20:22]) )[0]
+        results['DAC1'] = unpack("<H", pack("BB", *defaults[20:22]))[0]
 
         defaults = self.readDefaults(3)
 
@@ -1801,10 +1801,10 @@ class U3(Device):
         section = "FIOs"
         parser.add_section(section)
 
-        dirs, states = self.getFeedback( PortDirRead(), PortStateRead() )
+        dirs, states = self.getFeedback(PortDirRead(), PortStateRead())
 
-        parser.set(section, "FIOs Analog", str( self.readRegister(50590) ))
-        parser.set(section, "EIOs Analog", str( self.readRegister(50591) ))
+        parser.set(section, "FIOs Analog", str(self.readRegister(50590)))
+        parser.set(section, "EIOs Analog", str(self.readRegister(50591)))
 
         for key, value in dirs.items():
             parser.set(section, "%s Directions" % key, str(value))
@@ -1845,13 +1845,13 @@ class U3(Device):
         ec1 = timerCounterConfig['EnableCounter1']
         cpo = timerCounterConfig['TimerCounterPinOffset']
 
-        parser.set(section, "NumberTimersEnabled", str(nte) )
-        parser.set(section, "Counter0Enabled", str(ec0) )
-        parser.set(section, "Counter1Enabled", str(ec1) )
-        parser.set(section, "TimerCounterPinOffset", str(cpo) )
+        parser.set(section, "NumberTimersEnabled", str(nte))
+        parser.set(section, "Counter0Enabled", str(ec0))
+        parser.set(section, "Counter1Enabled", str(ec1))
+        parser.set(section, "TimerCounterPinOffset", str(cpo))
 
         for i in range(nte):
-            mode, value = self.readRegister(7100 + (2*i), numReg = 2, format = ">HH")
+            mode, value = self.readRegister(7100 + (2 * i), numReg=2, format=">HH")
             parser.set(section, "Timer%i Mode" % i, str(mode))
             parser.set(section, "Timer%i Value" % i, str(value))
 
@@ -1875,10 +1875,10 @@ class U3(Device):
                     raise Exception("Not a U3 Config file.")
 
             if parser.has_option(section, "local id"):
-                self.configU3( LocalID = parser.getint(section, "local id"))
+                self.configU3(LocalID=parser.getint(section, "local id"))
 
             if parser.has_option(section, "name"):
-                self.setName( parser.get(section, "name") )
+                self.setName(parser.get(section, "name"))
 
         # Set FIOs:
         section = "FIOs"
@@ -1913,9 +1913,9 @@ class U3(Device):
             if parser.has_option(section, "cios states"):
                 ciostates = parser.getint(section, "cios states")
 
-            self.configIO(FIOAnalog = fioanalog, EIOAnalog = eioanalog)
+            self.configIO(FIOAnalog=fioanalog, EIOAnalog=eioanalog)
 
-            self.getFeedback( PortStateWrite([fiostates, eiostates, ciostates]), PortDirWrite([fiodirs, eiodirs, ciodirs]) )
+            self.getFeedback(PortStateWrite([fiostates, eiostates, ciostates]), PortDirWrite([fiodirs, eiodirs, ciodirs]))
 
         # Set DACs:
         section = "DACs"
@@ -1930,7 +1930,7 @@ class U3(Device):
         section = "Timer Clock Speed Configuration"
         if parser.has_section(section):
             if parser.has_option(section, "timerclockbase") and parser.has_option(section, "timerclockdivisor"):
-                self.configTimerClock(TimerClockBase = parser.getint(section, "timerclockbase"), TimerClockDivisor = parser.getint(section, "timerclockdivisor"))
+                self.configTimerClock(TimerClockBase=parser.getint(section, "timerclockbase"), TimerClockDivisor=parser.getint(section, "timerclockdivisor"))
 
         # Set Timers / Counters
         section = "Timers And Counters"
@@ -1952,7 +1952,7 @@ class U3(Device):
             if parser.has_option(section, "Counter1Enabled"):
                 c1e = parser.getboolean(section, "Counter1Enabled")
 
-            self.configIO(NumberOfTimersEnabled = nte, EnableCounter1 = c1e, EnableCounter0 = c0e, TimerCounterPinOffset = cpo)
+            self.configIO(NumberOfTimersEnabled=nte, EnableCounter1=c1e, EnableCounter0=c0e, TimerCounterPinOffset=cpo)
 
 
             mode = None
@@ -1964,7 +1964,7 @@ class U3(Device):
                 if parser.has_option(section, "timer0 value"):
                     value = parser.getint(section, "timer0 value")
 
-                self.getFeedback( Timer0Config(mode, value) )
+                self.getFeedback(Timer0Config(mode, value))
 
             if parser.has_option(section, "timer1 mode"):
                 mode = parser.getint(section, "timer1 mode")
@@ -1972,7 +1972,7 @@ class U3(Device):
                 if parser.has_option(section, "timer1 value"):
                     value = parser.getint(section, "timer1 value")
 
-                self.getFeedback( Timer1Config(mode, value) )
+                self.getFeedback(Timer1Config(mode, value))
     loadConfig.section = 3
 
 class FeedbackCommand(object):
@@ -2002,7 +2002,7 @@ class AIN(FeedbackCommand):
     [36640]
     '''
     def __init__(self, PositiveChannel, NegativeChannel=31,
-            LongSettling=False, QuickSample=False):
+                 LongSettling=False, QuickSample=False):
         self.positiveChannel = PositiveChannel
         self.negativeChannel = NegativeChannel
         self.longSettling = LongSettling
@@ -2016,12 +2016,12 @@ class AIN(FeedbackCommand):
         b = PositiveChannel
         b |= (int(bool(LongSettling)) << 6)
         b |= (int(bool(QuickSample)) << 7)
-        self.cmdBytes = [ 0x01, b, NegativeChannel ]
+        self.cmdBytes = [0x01, b, NegativeChannel]
 
-    readLen =  2
+    readLen = 2
 
     def __repr__(self):
-        return "<u3.AIN( PositiveChannel = %s, NegativeChannel = %s, LongSettling = %s, QuickSample = %s )>" % ( self.positiveChannel, self.negativeChannel, self.longSettling, self.quickSample )
+        return "<u3.AIN( PositiveChannel = %s, NegativeChannel = %s, LongSettling = %s, QuickSample = %s )>" % (self.positiveChannel, self.negativeChannel, self.longSettling, self.quickSample)
 
     def handle(self, input):
         result = (input[1] << 8) + input[0]
@@ -2043,7 +2043,7 @@ class WaitShort(FeedbackCommand):
     '''
     def __init__(self, Time):
         self.time = Time % 256
-        self.cmdBytes = [ 5, Time % 256 ]
+        self.cmdBytes = [5, Time % 256]
 
     def __repr__(self):
         return "<u3.WaitShort( Time = %s )>" % self.time
@@ -2064,7 +2064,7 @@ class WaitLong(FeedbackCommand):
     '''
     def __init__(self, Time):
         self.time = Time % 256
-        self.cmdBytes = [ 6, Time % 256 ]
+        self.cmdBytes = [6, Time % 256]
 
     def __repr__(self):
         return "<u3.WaitLong( Time = %s )>" % self.time
@@ -2091,7 +2091,7 @@ class LED(FeedbackCommand):
     '''
     def __init__(self, State):
         self.state = State
-        self.cmdBytes = [ 9, int(bool(State)) ]
+        self.cmdBytes = [9, int(bool(State))]
 
     def __repr__(self):
         return "<u3.LED( State = %s )>" % self.state
@@ -2116,7 +2116,7 @@ class BitStateRead(FeedbackCommand):
     '''
     def __init__(self, IONumber):
         self.ioNumber = IONumber
-        self.cmdBytes = [ 10, IONumber % 20 ]
+        self.cmdBytes = [10, IONumber % 20]
 
     readLen = 1
 
@@ -2147,7 +2147,7 @@ class BitStateWrite(FeedbackCommand):
     def __init__(self, IONumber, State):
         self.ioNumber = IONumber
         self.state = State
-        self.cmdBytes = [ 11, (IONumber % 20) + (int(bool(State)) << 7) ]
+        self.cmdBytes = [11, (IONumber % 20) + (int(bool(State)) << 7)]
 
     def __repr__(self):
         return "<u3.BitStateWrite( IONumber = %s, State = %s )>" % (self.ioNumber, self.state)
@@ -2169,7 +2169,7 @@ class BitDirRead(FeedbackCommand):
     '''
     def __init__(self, IONumber):
         self.ioNumber = IONumber
-        self.cmdBytes = [ 12, IONumber % 20 ]
+        self.cmdBytes = [12, IONumber % 20]
 
     readLen = 1
 
@@ -2199,7 +2199,7 @@ class BitDirWrite(FeedbackCommand):
     def __init__(self, IONumber, Direction):
         self.ioNumber = IONumber
         self.direction = Direction
-        self.cmdBytes = [ 13, (IONumber % 20) + (int(bool(Direction)) << 7) ]
+        self.cmdBytes = [13, (IONumber % 20) + (int(bool(Direction)) << 7)]
 
     def __repr__(self):
         return "<u3.BitDirWrite( IONumber = %s, Direction = %s )>" % (self.ioNumber, self.direction)
@@ -2218,12 +2218,12 @@ class PortStateRead(FeedbackCommand):
     [{'CIO': 15, 'FIO': 224, 'EIO': 255}]
     """
     def __init__(self):
-        self.cmdBytes = [ 26 ]
+        self.cmdBytes = [26]
 
     readLen = 3
 
     def handle(self, input):
-        return {'FIO' : input[0], 'EIO' : input[1], 'CIO' : input[2] }
+        return {'FIO': input[0], 'EIO': input[1], 'CIO': input[2]}
 
     def __repr__(self):
         return "<u3.PortStateRead()>"
@@ -2244,10 +2244,10 @@ class PortStateWrite(FeedbackCommand):
     Response:  [0xfa, 0xf8, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]
     [None]
     """
-    def __init__(self, State, WriteMask = [0xff, 0xff, 0xff]):
+    def __init__(self, State, WriteMask=[0xff, 0xff, 0xff]):
         self.state = State
         self.writeMask = WriteMask
-        self.cmdBytes = [ 27 ] + WriteMask + State
+        self.cmdBytes = [27] + WriteMask + State
 
     def __repr__(self):
         return "<u3.PortStateWrite( State = %s, WriteMask = %s )>" % (self.state, self.writeMask)
@@ -2266,7 +2266,7 @@ class PortDirRead(FeedbackCommand):
     [{'CIO': 15, 'FIO': 240, 'EIO': 255}]
     """
     def __init__(self):
-        self.cmdBytes = [ 28 ]
+        self.cmdBytes = [28]
 
     readLen = 3
 
@@ -2274,7 +2274,7 @@ class PortDirRead(FeedbackCommand):
         return "<u3.PortDirRead()>"
 
     def handle(self, input):
-        return {'FIO' : input[0], 'EIO' : input[1], 'CIO' : input[2] }
+        return {'FIO': input[0], 'EIO': input[1], 'CIO': input[2]}
 
 class PortDirWrite(FeedbackCommand):
     """
@@ -2292,10 +2292,10 @@ class PortDirWrite(FeedbackCommand):
     Response:  [0xfa, 0xf8, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]
     [None]
     """
-    def __init__(self, Direction, WriteMask = [ 0xff, 0xff, 0xff]):
+    def __init__(self, Direction, WriteMask=[0xff, 0xff, 0xff]):
         self.direction = Direction
         self.writeMask = WriteMask
-        self.cmdBytes = [ 29 ] + WriteMask + Direction
+        self.cmdBytes = [29] + WriteMask + Direction
 
     def __repr__(self):
         return "<u3.PortDirWrite( Direction = %s, WriteMask = %s )>" % (self.direction, self.writeMask)
@@ -2320,7 +2320,7 @@ class DAC8(FeedbackCommand):
     def __init__(self, Dac, Value):
         self.dac = Dac
         self.value = Value % 256
-        self.cmdBytes = [ 34 + (Dac % 2), Value % 256 ]
+        self.cmdBytes = [34 + (Dac % 2), Value % 256]
 
     def __repr__(self):
         return "<u3.DAC8( Dac = %s, Value = %s )>" % (self.dac, self.value)
@@ -2389,7 +2389,7 @@ class DAC16(FeedbackCommand):
     def __init__(self, Dac, Value):
         self.dac = Dac
         self.value = Value
-        self.cmdBytes = [ 38 + (Dac % 2), Value % 256, Value >> 8 ]
+        self.cmdBytes = [38 + (Dac % 2), Value % 256, Value >> 8]
 
     def __repr__(self):
         return "<u3.DAC16( Dac = %s, Value = %s )>" % (self.dac, self.value)
@@ -2470,7 +2470,7 @@ class Timer(FeedbackCommand):
     Response:  [0xfc, 0xf8, 0x4, 0x0, 0xfe, 0x1, 0x0, 0x0, 0x0, 0x63, 0xdd, 0x4c, 0x72, 0x0]
     [1917640035]
     """
-    def __init__(self, timer, UpdateReset = False, Value=0, Mode = None):
+    def __init__(self, timer, UpdateReset=False, Value=0, Mode=None):
         self.timer = timer
         self.updateReset = UpdateReset
         self.value = Value
@@ -2481,7 +2481,7 @@ class Timer(FeedbackCommand):
             raise LabJackException("UpdateReset set but no value.")
 
 
-        self.cmdBytes = [ (42 + (2*timer)), UpdateReset, Value % 256, Value >> 8 ]
+        self.cmdBytes = [(42 + (2 * timer)), UpdateReset, Value % 256, Value >> 8]
 
     readLen = 4
 
@@ -2491,12 +2491,12 @@ class Timer(FeedbackCommand):
     def handle(self, input):
         inStr = pack('B' * len(input), *input)
         if self.mode == 8:
-            return unpack('<i', inStr )[0]
+            return unpack('<i', inStr)[0]
         elif self.mode == 9:
-            maxCount, current = unpack('<HH', inStr )
+            maxCount, current = unpack('<HH', inStr)
             return current, maxCount
         else:
-            return unpack('<I', inStr )[0]
+            return unpack('<I', inStr)[0]
 
 class Timer0(Timer):
     """
@@ -2524,7 +2524,7 @@ class Timer0(Timer):
     Response:  [0x51, 0xf8, 0x4, 0x0, 0x52, 0x2, 0x0, 0x0, 0x0, 0xf6, 0x90, 0x46, 0x86, 0x0]
     [2252771574]
     """
-    def __init__(self, UpdateReset = False, Value = 0, Mode = None):
+    def __init__(self, UpdateReset=False, Value=0, Mode=None):
         Timer.__init__(self, 0, UpdateReset, Value, Mode)
 
     def __repr__(self):
@@ -2556,7 +2556,7 @@ class Timer1(Timer):
     Response:  [0x8d, 0xf8, 0x4, 0x0, 0x8e, 0x2, 0x0, 0x0, 0x0, 0xf3, 0x31, 0xd0, 0x9a, 0x0]
     [2597335539]
     """
-    def __init__(self, UpdateReset = False, Value = 0, Mode = None):
+    def __init__(self, UpdateReset=False, Value=0, Mode=None):
         Timer.__init__(self, 1, UpdateReset, Value, Mode)
 
     def __repr__(self):
@@ -2598,8 +2598,8 @@ class QuadratureInputTimer(Timer):
     Response:  [0x9, 0xf8, 0x4, 0x0, 0xc, 0x0, 0x0, 0x0, 0x0, 0xc, 0x0, 0x0, 0x0, 0x0]
     [12]
     """
-    def __init__(self, UpdateReset = False, Value = 0):
-        Timer.__init__(self, 0, UpdateReset, Value, Mode = 8)
+    def __init__(self, UpdateReset=False, Value=0):
+        Timer.__init__(self, 0, UpdateReset, Value, Mode=8)
 
     def __repr__(self):
         return "<u3.QuadratureInputTimer( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)
@@ -2635,8 +2635,8 @@ class TimerStopInput1(Timer1):
     Response:  [0x1b, 0xf8, 0x4, 0x0, 0x1e, 0x0, 0x0, 0x0, 0x0, 0x1e, 0x0, 0x0, 0x0, 0x0]
     [(0, 0)]
     """
-    def __init__(self, UpdateReset = False, Value = 0):
-        Timer1.__init__(self, UpdateReset, Value, Mode = 9)
+    def __init__(self, UpdateReset=False, Value=0):
+        Timer1.__init__(self, UpdateReset, Value, Mode=9)
 
     def __repr__(self):
         return "<u3.TimerStopInput1( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)
@@ -2669,7 +2669,7 @@ class TimerConfig(FeedbackCommand):
     """
     def __init__(self, timer, TimerMode, Value=0):
         '''Creates command bytes for configureing a Timer'''
-        #Conditions come from pages 33-34 of user's guide
+        # Conditions come from pages 33-34 of user's guide
         if timer != 0 and timer != 1:
             raise LabJackException("Timer should be either 0 or 1.")
 
@@ -2709,7 +2709,7 @@ class Timer0Config(TimerConfig):
     Response:  [0xfa, 0xf8, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]
     [None]
     """
-    def __init__(self, TimerMode, Value = 0):
+    def __init__(self, TimerMode, Value=0):
         TimerConfig.__init__(self, 0, TimerMode, Value)
 
     def __repr__(self):
@@ -2735,7 +2735,7 @@ class Timer1Config(TimerConfig):
     Response:  [0xfa, 0xf8, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]
     [None]
     """
-    def __init__(self, TimerMode, Value = 0):
+    def __init__(self, TimerMode, Value=0):
         TimerConfig.__init__(self, 1, TimerMode, Value)
 
     def __repr__(self):
@@ -2770,7 +2770,7 @@ class Counter(FeedbackCommand):
     Response:  [0xe9, 0xf8, 0x4, 0x0, 0xec, 0x0, 0x0, 0x0, 0x0, 0xe8, 0x4, 0x0, 0x0, 0x0]
     [1256]
     '''
-    def __init__(self, counter, Reset = False):
+    def __init__(self, counter, Reset=False):
         self.counter = counter
         self.reset = Reset
         self.cmdBytes = [54 + (counter % 2), int(bool(Reset))]
@@ -2818,7 +2818,7 @@ class Counter0(Counter):
     Response:  [0x19, 0xf8, 0x4, 0x0, 0x1c, 0x0, 0x0, 0x0, 0x0, 0xb, 0x11, 0x0, 0x0, 0x0]
     [4363]
     '''
-    def __init__(self, Reset = False):
+    def __init__(self, Reset=False):
         Counter.__init__(self, 0, Reset)
 
     def __repr__(self):
@@ -2858,7 +2858,7 @@ class Counter1(Counter):
     Response:  [0xb4, 0xf8, 0x4, 0x0, 0xb7, 0x0, 0x0, 0x0, 0x0, 0x6b, 0x2b, 0x21, 0x0, 0x0]
     [2173803]
     '''
-    def __init__(self, Reset = False):
+    def __init__(self, Reset=False):
         Counter.__init__(self, 1, Reset)
 
     def __repr__(self):

--- a/src/u3.py
+++ b/src/u3.py
@@ -27,16 +27,11 @@ except ImportError:  # Python 3
 
 from struct import pack, unpack
 
-from LabJackPython import (
-    Device,
-    deviceCount,
-    LabJackException,
-    LowlevelErrorException,
-    lowlevelErrorToString,
-    MAX_USB_PACKET_LENGTH,
-    setChecksum8,
-    toDouble,
-    )
+from LabJackPython import (Device, deviceCount, LabJackException,
+                           LowlevelErrorException,
+                           lowlevelErrorToString,
+                           MAX_USB_PACKET_LENGTH, setChecksum8,
+                           toDouble)
 
 
 FIO0, FIO1, FIO2, FIO3, FIO4, FIO5, FIO6, FIO7, \
@@ -389,7 +384,6 @@ class U3(Device):
         self.counter0Enabled = bool((self.timerCounterConfig >> 2) & 1)
         self.counter1Enabled = bool((self.timerCounterConfig >> 3) & 1)
         self.timerCounterPinOffset = (self.timerCounterConfig >> 4)
-
 
         self.dac1Enable = result[9]
         self.fioAnalog = result[10]
@@ -753,7 +747,6 @@ class U3(Device):
         if readLen % 2:
             readLen += 1
 
-
         if len(sendBuffer) > MAX_USB_PACKET_LENGTH:
             raise LabJackException("ERROR: The feedback command you are attempting to send is bigger than 64 bytes ( %s bytes ). Break your commands up into separate calls to getFeedback()." % len(sendBuffer))
 
@@ -775,7 +768,6 @@ class U3(Device):
                 culprit = commandlist[(rcvBuffer[7] - 1)]
 
             raise LowlevelErrorException("\nThis Command\n    %s\nreturned an error:\n    %s" % (culprit, lowlevelErrorToString(rcvBuffer[6])))
-
 
         results = []
         i = 9
@@ -858,7 +850,6 @@ class U3(Device):
         command[6] = 0x00
         command[7] = blockNum
         command[8:] = data
-
 
         self._writeRead(command, 8, [0xF8, 0x01, command[3]])
     writeMem.section = 2
@@ -1176,7 +1167,6 @@ class U3(Device):
         command[9] = ord(t[1])
 
         command[10] = ((DIOState & 1) << 7) + (DIONumber & 15)
-
 
         result = self._writeRead(command, 16, [0xF8, 0x05, 0x09])
 
@@ -1978,6 +1968,7 @@ class FeedbackCommand(object):
     The FeedbackCommand class is the base for all the Feedback commands.
     """
     readLen = 0
+
     def handle(self, input):
         return None
 

--- a/src/u6.py
+++ b/src/u6.py
@@ -47,6 +47,7 @@ def openAllU6():
 
     return returnDict
 
+
 def dumpPacket(buffer):
     """
     Name: dumpPacket(buffer)
@@ -54,6 +55,7 @@ def dumpPacket(buffer):
     Desc: Returns hex value of all bytes in the buffer
     """
     return repr([hex(x) for x in buffer])
+
 
 def getBit(n, bit):
     """
@@ -73,6 +75,7 @@ def getBit(n, bit):
     """
     return int(bool((int(n) & (1 << bit)) >> bit))
 
+
 def toBitList(inbyte):
     """
     Name: toBitList(inbyte)
@@ -85,6 +88,7 @@ def toBitList(inbyte):
 
     """
     return [getBit(inbyte, b) for b in range(8)]
+
 
 def dictAsString(d):
     """Helper function that returns a string representation of a dictionary"""
@@ -169,7 +173,6 @@ class CalibrationInfo(object):
 
         self.proAinNegSlope = [self.proAin10vNegSlope, self.proAin1vNegSlope, self.proAin100mvNegSlope, self.proAin10mvNegSlope]
         self.proAinCenter = [self.proAin10vCenter, self.proAin1vCenter, self.proAin100mvCenter, self.proAin10mvCenter]
-
 
     def __str__(self):
         return str(self.__dict__)
@@ -1542,7 +1545,6 @@ class U6(Device):
         for key, value in ioconfig.items():
             parser.set(section, key, str(value))
 
-
         for i in range(ioconfig['NumberTimersEnabled']):
             mode, value = self.readRegister(7100 + (2 * i), numReg=2, format=">HH")
             parser.set(section, "Timer%s Mode" % i, str(mode))
@@ -1635,7 +1637,6 @@ class U6(Device):
 
             self.configIO(NumberTimersEnabled=nte, EnableCounter1=c1e, EnableCounter0=c0e, TimerCounterPinOffset=cpo)
 
-
             mode = None
             value = None
 
@@ -1647,6 +1648,7 @@ class U6(Device):
                         value = parser.getint(section, "timer%i value" % i)
 
                     self.getFeedback(TimerConfig(i, mode, value))
+
 
 class FeedbackCommand(object):
     '''
@@ -1660,6 +1662,7 @@ class FeedbackCommand(object):
         return None
 
 _validChannels = frozenset(range(144))
+
 
 class AIN(FeedbackCommand):
     '''
@@ -1692,6 +1695,7 @@ class AIN(FeedbackCommand):
     def handle(self, input):
         result = (input[1] << 8) + input[0]
         return result
+
 
 class AIN24(FeedbackCommand):
     '''
@@ -1746,6 +1750,7 @@ class AIN24(FeedbackCommand):
         # Put it all into an integer.
         result = (input[2] << 16) + (input[1] << 8) + input[0]
         return result
+
 
 class AIN24AR(FeedbackCommand):
     '''
@@ -1808,6 +1813,7 @@ class AIN24AR(FeedbackCommand):
 
         return {'AIN': result, 'ResolutionIndex': resolutionIndex, 'GainIndex': gainIndex, 'Status': status}
 
+
 class WaitShort(FeedbackCommand):
     '''
     WaitShort Feedback command
@@ -1824,6 +1830,7 @@ class WaitShort(FeedbackCommand):
     def __repr__(self):
         return "<u6.WaitShort( Time = %s )>" % self.time
 
+
 class WaitLong(FeedbackCommand):
     '''
     WaitLong Feedback command
@@ -1839,6 +1846,7 @@ class WaitLong(FeedbackCommand):
 
     def __repr__(self):
         return "<u6.WaitLog( Time = %s )>" % self.time
+
 
 class LED(FeedbackCommand):
     '''
@@ -1857,6 +1865,7 @@ class LED(FeedbackCommand):
 
     def __repr__(self):
         return "<u6.LED( State = %s )>" % self.state
+
 
 class BitStateRead(FeedbackCommand):
     '''
@@ -1883,6 +1892,7 @@ class BitStateRead(FeedbackCommand):
     def handle(self, input):
         return int(bool(input[0]))
 
+
 class BitStateWrite(FeedbackCommand):
     '''
     BitStateWrite Feedback command
@@ -1903,6 +1913,7 @@ class BitStateWrite(FeedbackCommand):
 
     def __repr__(self):
         return "<u6.BitStateWrite( IONumber = %s, State = %s )>" % self.ioNumber
+
 
 class BitDirRead(FeedbackCommand):
     '''
@@ -1926,6 +1937,7 @@ class BitDirRead(FeedbackCommand):
     def handle(self, input):
         return int(bool(input[0]))
 
+
 class BitDirWrite(FeedbackCommand):
     '''
     BitDirWrite Feedback command
@@ -1945,6 +1957,7 @@ class BitDirWrite(FeedbackCommand):
 
     def __repr__(self):
         return "<u6.BitDirWrite( IONumber = %s, Direction = %s )>" % (self.ioNumber, self.direction)
+
 
 class PortStateRead(FeedbackCommand):
     """
@@ -1966,6 +1979,7 @@ class PortStateRead(FeedbackCommand):
     def handle(self, input):
         return {'FIO': input[0], 'EIO': input[1], 'CIO': input[2]}
 
+
 class PortStateWrite(FeedbackCommand):
     """
     PortStateWrite Feedback command
@@ -1986,6 +2000,7 @@ class PortStateWrite(FeedbackCommand):
     def __repr__(self):
         return "<u6.PortStateWrite( State = %s, WriteMask = %s )>" % (self.state, self.writeMask)
 
+
 class PortDirRead(FeedbackCommand):
     """
     PortDirRead Feedback command
@@ -2005,6 +2020,7 @@ class PortDirRead(FeedbackCommand):
     def handle(self, input):
         return {'FIO': input[0], 'EIO': input[1], 'CIO': input[2]}
 
+
 class PortDirWrite(FeedbackCommand):
     """
     PortDirWrite Feedback command
@@ -2023,6 +2039,7 @@ class PortDirWrite(FeedbackCommand):
 
     def __repr__(self):
         return "<u6.PortDirWrite( Direction = %s, WriteMask = %s )>" % (self.direction, self.writeMask)
+
 
 class DAC8(FeedbackCommand):
     '''
@@ -2044,6 +2061,7 @@ class DAC8(FeedbackCommand):
     def __repr__(self):
         return "<u6.DAC8( Dac = %s, Value = %s )>" % (self.dac, self.value)
 
+
 class DAC0_8(DAC8):
     """
     8-bit DAC Feedback command for DAC0
@@ -2061,6 +2079,7 @@ class DAC0_8(DAC8):
     def __repr__(self):
         return "<u6.DAC0_8( Value = %s )>" % self.value
 
+
 class DAC1_8(DAC8):
     """
     8-bit DAC Feedback command for DAC1
@@ -2077,6 +2096,7 @@ class DAC1_8(DAC8):
 
     def __repr__(self):
         return "<u6.DAC1_8( Value = %s )>" % self.value
+
 
 class DAC16(FeedbackCommand):
     '''
@@ -2098,6 +2118,7 @@ class DAC16(FeedbackCommand):
     def __repr__(self):
         return "<u6.DAC8( Dac = %s, Value = %s )>" % (self.dac, self.value)
 
+
 class DAC0_16(DAC16):
     """
     16-bit DAC Feedback command for DAC0
@@ -2114,6 +2135,7 @@ class DAC0_16(DAC16):
 
     def __repr__(self):
         return "<u6.DAC0_16( Value = %s )>" % self.value
+
 
 class DAC1_16(DAC16):
     """

--- a/src/u6.py
+++ b/src/u6.py
@@ -78,11 +78,11 @@ def toBitList(inbyte):
     Name: toBitList(inbyte)
     Args: a byte
     Desc: Converts a byte into list for access to individual bits
-    
+
     >>> inbyte = 5
     >>> toBitList(inbyte)
     [1, 0, 1, 0, 0, 0, 0, 0]
-    
+
     """
     return [ getBit(inbyte, b) for b in range(8) ]
 
@@ -101,7 +101,7 @@ class CalibrationInfo(object):
     def __init__(self):
         # A flag to tell difference between nominal and actual values.
         self.nominal = True
-    
+
         # Positive Channel calibration
         self.ain10vSlope = 3.1580578 * (10 ** -4)
         self.ain10vOffset = -10.5869565220
@@ -124,25 +124,25 @@ class CalibrationInfo(object):
         self.ain100mvCenter = 33523.0
         self.ain10mvNegSlope = -3.15805800 * (10 ** -7)
         self.ain10mvCenter = 33523.0
-        
+
         self.ainNegSlope = [self.ain10vNegSlope, self.ain1vNegSlope, self.ain100mvNegSlope, self.ain10mvNegSlope]
         self.ainCenter = [self.ain10vCenter, self.ain1vCenter, self.ain100mvCenter, self.ain10mvCenter]
-        
+
         # Miscellaneous
         self.dac0Slope = 13200.0
         self.dac0Offset = 0
         self.dac1Slope = 13200.0
         self.dac1Offset = 0
-        
+
         self.dacSlope = [self.dac0Slope, self.dac1Slope]
         self.dacOffset = [self.dac0Offset, self.dac1Offset]
 
         self.currentOutput0 = 0.0000100000
         self.currentOutput1 = 0.0002000000
-        
+
         self.temperatureSlope = -92.379
         self.temperatureOffset = 465.129
-        
+
         # Hi-Res ADC stuff
         # Positive Channel calibration
         self.proAin10vSlope = 3.1580578 * (10 ** -4)
@@ -153,10 +153,10 @@ class CalibrationInfo(object):
         self.proAin100mvOffset = -0.105869565220
         self.proAin10mvSlope = 3.1580578 * (10 ** -7)
         self.proAin10mvOffset = -0.0105869565220
-        
+
         self.proAinSlope = [self.proAin10vSlope, self.proAin1vSlope, self.proAin100mvSlope, self.proAin10mvSlope]
         self.proAinOffset = [self.proAin10vOffset, self.proAin1vOffset, self.proAin100mvOffset, self.proAin10mvOffset]
-        
+
         # Negative Channel calibration
         self.proAin10vNegSlope = -3.15805800 * (10 ** -4)
         self.proAin10vCenter = 33523.0
@@ -166,7 +166,7 @@ class CalibrationInfo(object):
         self.proAin100mvCenter = 33523.0
         self.proAin10mvNegSlope = -3.15805800 * (10 ** -7)
         self.proAin10mvCenter = 33523.0
-        
+
         self.proAinNegSlope = [self.proAin10vNegSlope, self.proAin1vNegSlope, self.proAin100mvNegSlope, self.proAin10mvNegSlope]
         self.proAinCenter = [self.proAin10vCenter, self.proAin1vCenter, self.proAin100mvCenter, self.proAin10mvCenter]
 
@@ -178,7 +178,7 @@ class CalibrationInfo(object):
 class U6(Device):
     """
     U6 Class for all U6 specific low-level commands.
-    
+
     Example:
     >>> import u6
     >>> d = u6.U6()
@@ -226,7 +226,7 @@ class U6(Device):
               handleOnly, if True, LabJackPython will only open a handle
               LJSocket, set to "<ip>:<port>" to connect to LJSocket
         Desc: Opens a U6 for reading and writing.
-        
+
         >>> myU6 = u6.U6(autoOpen = False)
         >>> myU6.open()
         """
@@ -260,10 +260,10 @@ class U6(Device):
         if LocalID is not None:
             command[6] = (1 << 3)
             command[8] = LocalID
-            
+
         #command[7] = Reserved
 
-        #command[9-25] = Reserved 
+        #command[9-25] = Reserved
         try:
             result = self._writeRead(command, 38, [0xF8, 0x10, 0x08])
         except LabJackException:
@@ -275,7 +275,7 @@ class U6(Device):
                 raise e
 
         self.firmwareVersion = "%s.%02d" % (result[10], result[9])
-        self.bootloaderVersion = "%s.%02d" % (result[12], result[11]) 
+        self.bootloaderVersion = "%s.%02d" % (result[12], result[11])
         self.hardwareVersion = "%s.%02d" % (result[14], result[13])
         self.serialNumber = unpack("<I", pack(">BBBB", *result[15:19]))[0]
         self.productId = unpack("<H", pack(">BB", *result[19:21]))[0]
@@ -297,11 +297,11 @@ class U6(Device):
               EnableCounter1, Set to True to enable counter 1, F to disable
               EnableCounter0, Set to True to enable counter 0, F to disable
               TimerCounterPinOffset, where should the timers/counters start
-              
+
               if all args are None, command just reads.
-              
+
         Desc: Writes and reads the current IO configuration.
-        
+
         >>> myU6 = u6.U6()
         >>> myU6.configIO()
         {'Counter0Enabled': False,
@@ -310,40 +310,40 @@ class U6(Device):
          'TimerCounterPinOffset': 0}
         """
         command = [ 0 ] * 16
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x05
         command[3] = 0x0B
         #command[4]  = Checksum16 (LSB)
         #command[5]  = Checksum16 (MSB)
-        
+
         if NumberTimersEnabled is not None:
             command[6] = 1
             command[7] = NumberTimersEnabled
-        
+
         if EnableCounter0 is not None:
             command[6] = 1
-            
+
             if EnableCounter0:
                 command[8] = 1
-        
+
         if EnableCounter1 is not None:
             command[6] = 1
-            
+
             if EnableCounter1:
                 command[8] |= (1 << 1)
-        
+
         if TimerCounterPinOffset is not None:
             command[6] = 1
             command[9] = TimerCounterPinOffset
-            
+
         if EnableUART is not None:
             command[6] |= 1
             command[6] |= (1 << 5)
-        
+
         result = self._writeRead(command, 16, [0xf8, 0x05, 0x0B])
-        
+
         return { 'NumberTimersEnabled' : result[8], 'Counter0Enabled' : bool(result[9] & 1), 'Counter1Enabled' : bool( (result[9] >> 1) & 1), 'TimerCounterPinOffset' : result[10] }
 
     def configTimerClock(self, TimerClockBase = None, TimerClockDivisor = None):
@@ -352,18 +352,18 @@ class U6(Device):
                                   TimerClockDivisor = None)
         Args: TimerClockBase, which timer base to use
               TimerClockDivisor, set the divisor
-              
+
               if all args are None, command just reads.
               Also, you cannot set the divisor without setting the base.
-              
+
         Desc: Writes and read the timer clock configuration.
-        
+
         >>> myU6 = u6.U6()
         >>> myU6.configTimerClock()
         {'TimerClockDivisor': 256, 'TimerClockBase': 2}
         """
         command = [ 0 ] * 10
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
@@ -372,16 +372,16 @@ class U6(Device):
         #command[5]  = Checksum16 (MSB)
         #command[6]  = Reserved
         #command[7]  = Reserved
-        
+
         if TimerClockBase is not None:
             command[8] = (1 << 7)
             command[8] |= TimerClockBase & 7
-        
+
         if TimerClockDivisor is not None:
             command[9] = TimerClockDivisor
-            
+
         result = self._writeRead(command, 10, [0xF8, 0x2, 0x0A])
-        
+
         divisor = result[9]
         if divisor == 0:
             divisor = 256
@@ -395,7 +395,7 @@ class U6(Device):
             elif isinstance(cmd, list):
                 sendBuffer, readLen = self._buildBuffer(sendBuffer, readLen, cmd)
         return (sendBuffer, readLen)
-                
+
     def _buildFeedbackResults(self, rcvBuffer, commandlist, results, i):
         for cmd in commandlist:
             if isinstance(cmd, FeedbackCommand):
@@ -411,7 +411,7 @@ class U6(Device):
         Args: the FeedbackCommands to run
         Desc: Forms the commandlist into a packet, sends it to the U6, and reads
               the response.
-        
+
         >>> myU6 = U6()
         >>> ledCommand = u6.LED(False)
         >>> internalTempCommand = u6.AIN(30, 31, True)
@@ -419,7 +419,7 @@ class U6(Device):
         [None, 23200]
 
         OR if you like the list version better:
-        
+
         >>> myU6 = U6()
         >>> ledCommand = u6.LED(False)
         >>> internalTempCommand = u6.AIN(30, 31, True)
@@ -435,22 +435,22 @@ class U6(Device):
         if len(sendBuffer) % 2:
             sendBuffer += [0]
         sendBuffer[2] = len(sendBuffer) // 2 - 3
-        
+
         if readLen % 2:
             readLen += 1
-            
+
         if len(sendBuffer) > MAX_USB_PACKET_LENGTH:
             raise LabJackException("ERROR: The feedback command you are attempting to send is bigger than 64 bytes ( %s bytes ). Break your commands up into separate calls to getFeedback()." % len(sendBuffer))
-        
+
         if readLen > MAX_USB_PACKET_LENGTH:
             raise LabJackException("ERROR: The feedback command you are attempting to send would yield a response that is greater than 64 bytes ( %s bytes ). Break your commands up into separate calls to getFeedback()." % readLen)
-        
+
         rcvBuffer = self._writeRead(sendBuffer, readLen, [], checkBytes = False, stream = False, checksum = True)
-        
+
         # Check the response for errors
         try:
             self._checkCommandBytes(rcvBuffer, [0xF8])
-        
+
             if rcvBuffer[3] != 0x00:
                 raise LabJackException("Got incorrect command bytes")
         except LowlevelErrorException:
@@ -458,9 +458,9 @@ class U6(Device):
                 culprit = commandlist[0][ (rcvBuffer[7] - 1) ]
             else:
                 culprit = commandlist[ (rcvBuffer[7] -1) ]
-            
+
             raise LowlevelErrorException("\nThis Command\n    %s\nreturned an error:\n    %s" %  ( culprit, lowlevelErrorToString(rcvBuffer[6]) ) )
-        
+
         results = []
         i = 9
         return self._buildFeedbackResults(rcvBuffer, commandlist, results, i)
@@ -470,18 +470,18 @@ class U6(Device):
         Name: U6.readMem(BlockNum, ReadCal=False)
         Args: BlockNum, which block to read
               ReadCal, set to True to read the calibration data
-        Desc: Reads 1 block (32 bytes) from the non-volatile user or 
+        Desc: Reads 1 block (32 bytes) from the non-volatile user or
               calibration memory. Please read section 5.2.6 of the user's
               guide before you do something you may regret.
-        
+
         >>> myU6 = U6()
         >>> myU6.readMem(0)
         [ < userdata stored in block 0 > ]
-        
+
         NOTE: Do not call this function while streaming.
         """
         command = [ 0 ] * 8
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
@@ -492,34 +492,34 @@ class U6(Device):
         #command[5] = Checksum16 (MSB)
         command[6] = 0x00
         command[7] = BlockNum
-        
+
         result = self._writeRead(command, 40, [ 0xF8, 0x11, command[3] ])
-        
+
         return result[8:]
-    
+
     def readCal(self, BlockNum):
         return self.readMem(BlockNum, ReadCal = True)
-        
+
     def writeMem(self, BlockNum, Data, WriteCal=False):
         """
         Name: U6.writeMem(BlockNum, Data, WriteCal=False)
         Args: BlockNum, which block to write
               Data, a list of bytes to write
               WriteCal, set to True to write calibration.
-        Desc: Writes 1 block (32 bytes) from the non-volatile user or 
+        Desc: Writes 1 block (32 bytes) from the non-volatile user or
               calibration memory. Please read section 5.2.7 of the user's
               guide before you do something you may regret.
-        
+
         >>> myU6 = U6()
         >>> myU6.writeMem(0, [ < userdata to be stored in block 0 > ])
-        
+
         NOTE: Do not call this function while streaming.
         """
         if not isinstance(Data, list):
             raise LabJackException("Data must be a list of bytes")
-        
+
         command = [ 0 ] * 40
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x11
@@ -531,12 +531,12 @@ class U6(Device):
         command[6] = 0x00
         command[7] = BlockNum
         command[8:] = Data
-        
+
         self._writeRead(command, 8, [0xF8, 0x01, command[3]])
 
     def writeCal(self, BlockNum, Data):
         return self.writeMem(BlockNum, Data, WriteCal = True)
-        
+
     def eraseMem(self, EraseCal=False):
         """
         Name: U6.eraseMem(EraseCal=False)
@@ -552,10 +552,10 @@ class U6(Device):
         """
         if not isinstance(EraseCal, bool):
             raise LabJackException("EraseCal must be a Boolean value (True or False).")
-        
+
         if EraseCal:
             command = [ 0 ] * 8
-            
+
             #command[0] = Checksum8
             command[1] = 0xF8
             command[2] = 0x01
@@ -566,14 +566,14 @@ class U6(Device):
             command[7] = 0x6C
         else:
             command = [ 0 ] * 6
-            
+
             #command[0] = Checksum8
             command[1] = 0xF8
             command[2] = 0x00
             command[3] = 0x29
             #command[4] = Checksum16 (LSB)
             #command[5] = Checksum16 (MSB)
-        
+
         self._writeRead(command, 8, [0xF8, 0x01, command[3]])
 
     def eraseCal(self):
@@ -613,7 +613,7 @@ class U6(Device):
               See Section 5.2.12 of the User's Guide for more details.
 
               Deprecated:
-              
+
               SampleFrequency, the frequency in Hz to sample.  Use ScanFrequency
                                since SampleFrequency has always set the scan
                                frequency and the name is confusing.
@@ -748,7 +748,7 @@ class U6(Device):
         Desc: Controls a firmware based watchdog timer.
         """
         command = [ 0 ] * 16
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x05
@@ -761,43 +761,43 @@ class U6(Device):
             command[7] = (1 << 5)
         if SetDIOStateOnTimeout:
             command[7] |= (1 << 4)
-        
+
         t = pack("<H", TimeoutPeriod)
         command[8] = ord(t[0])
         command[9] = ord(t[1])
         command[10] = ((DIOState & 1 ) << 7)
         command[10] |= (DIONumber & 0xf)
-        
+
         result = self._writeRead(command, 16, [ 0xF8, 0x05, 0x09])
-        
+
         watchdogStatus = {}
-        
+
         if result[7] == 0:
             watchdogStatus['WatchDogEnabled'] = False
             watchdogStatus['ResetOnTimeout'] = False
             watchdogStatus['SetDIOStateOnTimeout'] = False
         else:
             watchdogStatus['WatchDogEnabled'] = True
-            
+
             if (result[7] >> 5) & 1:
                 watchdogStatus['ResetOnTimeout'] = True
             else:
                 watchdogStatus['ResetOnTimeout'] = False
-                
+
             if (result[7] >> 4) & 1:
                 watchdogStatus['SetDIOStateOnTimeout'] = True
             else:
                 watchdogStatus['SetDIOStateOnTimeout'] = False
-        
+
         watchdogStatus['TimeoutPeriod'] = unpack('<H', pack("BB", *result[8:10]))
-        
+
         if (result[10] >> 7) & 1:
             watchdogStatus['DIOState'] = 1
         else:
-            watchdogStatus['DIOState'] = 0 
-        
+            watchdogStatus['DIOState'] = 0
+
         watchdogStatus['DIONumber'] = ( result[10] & 15 )
-        
+
         return watchdogStatus
 
     def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 0, CLKPinNum = 1, MISOPinNum = 2, MOSIPinNum = 3, CSPINNum = None):
@@ -805,20 +805,20 @@ class U6(Device):
         Name: U6.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
                      SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 0,
                      CLKPinNum = 1, MISOPinNum = 2, MOSIPinNum = 3)
-        
+
         Args: SPIBytes, A list of bytes to send.
               AutoCS, If True, the CS line is automatically driven low
                       during the SPI communication and brought back high
                       when done.
               DisableDirConfig, If True, function does not set the direction
                                 of the line.
-              SPIMode, 'A', 'B', 'C',  or 'D'. 
+              SPIMode, 'A', 'B', 'C',  or 'D'.
               SPIClockFactor, Sets the frequency of the SPI clock.
               CSPinNum, which pin is CS
               CLKPinNum, which pin is CLK
               MISOPinNum, which pin is MISO
               MOSIPinNum, which pin is MOSI
-        
+
         Desc: Sends and receives serial data using SPI synchronous
               communication. See Section 5.2.17 of the user's guide.
 
@@ -831,36 +831,36 @@ class U6(Device):
         if CSPINNum is not None:
             warnings.warn("CSPINNum is deprecated, use CSPinNum instead", DeprecationWarning)
             CSPinNum = CSPINNum
-        
+
         numSPIBytes = len(SPIBytes)
-        
+
         oddPacket = False
         if numSPIBytes%2 != 0:
             SPIBytes.append(0)
             numSPIBytes = numSPIBytes + 1
             oddPacket = True
-        
+
         command = [ 0 ] * (13 + numSPIBytes)
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 4 + (numSPIBytes/2)
         command[3] = 0x3A
         #command[4] = Checksum16 (LSB)
         #command[5] = Checksum16 (MSB)
-        
+
         if AutoCS:
             command[6] |= (1 << 7)
         if DisableDirConfig:
             command[6] |= (1 << 6)
-        
+
         spiModes = ('A', 'B', 'C', 'D')
         try:
             modeIndex = spiModes.index(SPIMode)
         except ValueError:
             raise LabJackException("Invalid SPIMode %r, valid modes are: %r" % (SPIMode, spiModes))
         command[6] |= modeIndex
-        
+
         command[7] = SPIClockFactor
         #command[8] = Reserved
         command[9] = CSPinNum
@@ -870,11 +870,11 @@ class U6(Device):
         command[13] = numSPIBytes
         if oddPacket:
             command[13] = numSPIBytes - 1
-        
+
         command[14:] = SPIBytes
-        
+
         result = self._writeRead(command, 8+numSPIBytes, [ 0xF8, 1+(numSPIBytes/2), 0x3A ])
-        
+
         if result[6] != 0:
             raise LowlevelErrorException(result[6], "The spi command returned an error:\n    %s" % lowlevelErrorToString(result[6]))
 
@@ -882,23 +882,23 @@ class U6(Device):
 
     def asynchConfig(self, Update = True, UARTEnable = True, DesiredBaud = None, BaudFactor = 63036):
         """
-        Name: U6.asynchConfig(Update = True, UARTEnable = True, 
+        Name: U6.asynchConfig(Update = True, UARTEnable = True,
                               DesiredBaud = None, BaudFactor = 63036)
         Args: Update, If True, new values are written.
               UARTEnable, If True, UART will be enabled.
-              DesiredBaud, If set, will apply the formualt to 
+              DesiredBaud, If set, will apply the formualt to
                            calculate BaudFactor.
               BaudFactor, = 2^16 - 48000000/(2 * Desired Baud). Ignored
                         if DesiredBaud is set.
         Desc: Configures the U6 UART for asynchronous communication. See
               section 5.2.18 of the User's Guide.
         """
-        
+
         if UARTEnable:
             self.configIO(EnableUART = True)
-        
+
         command = [ 0 ] * 10
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
@@ -910,19 +910,19 @@ class U6(Device):
             command[7] = (1 << 7)
         if UARTEnable:
             command[7] |= (1 << 6)
-        
+
         if DesiredBaud is not None:
-            BaudFactor = (2**16) - 48000000/(2 * DesiredBaud)   
-        
+            BaudFactor = (2**16) - 48000000/(2 * DesiredBaud)
+
         t = pack("<H", BaudFactor)
         command[8] = ord(t[0])
         command[9] = ord(t[1])
-        
+
         results = self._writeRead(command, 10, [0xF8, 0x02, 0x14])
-            
+
         if command[8] != results[8] and command[9] != results[9]:
             raise LabJackException("BaudFactor didn't stick.")
-        
+
     def asynchTX(self, AsynchBytes):
         """
         Name: U6.asynchTX(AsynchBytes)
@@ -930,15 +930,15 @@ class U6(Device):
         Desc: Sends bytes to the U6 UART which will be sent asynchronously
               on the transmit line. Section 5.2.19 of the User's Guide.
         """
-        
+
         numBytes = len(AsynchBytes)
-        
+
         oddPacket = False
         if numBytes%2 != 0:
             oddPacket = True
             AsynchBytes.append(0)
             numBytes = numBytes + 1
-        
+
         command = [ 0 ] * (8+numBytes)
         #command[0] = Checksum8
         command[1] = 0xF8
@@ -951,11 +951,11 @@ class U6(Device):
         if oddPacket:
             command[7] = numBytes-1
         command[8:] = AsynchBytes
-        
+
         result = self._writeRead(command, 10, [ 0xF8, 0x02, 0x15])
-        
+
         return { 'NumAsynchBytesSent' : result[7], 'NumAsynchBytesInRXBuffer' : result[8] }
-    
+
     def asynchRX(self, Flush = False):
         """
         Name: U6.asynchTX(AsynchBytes)
@@ -964,9 +964,9 @@ class U6(Device):
               on the transmit line. Section 5.2.20 of the User's Guide.
         """
         command = [ 0, 0xF8, 0x01, 0x16, 0, 0, 0, int(Flush)]
-        
+
         result = self._writeRead(command, 40, [ 0xF8, 0x11, 0x16 ])
-        
+
         return { 'NumAsynchBytesInRXBuffer' : result[7], 'AsynchBytes' : result[8:] }
 
     def i2c(self, Address, I2CBytes, EnableClockStretching = False, NoStopWhenRestarting = False, ResetAtStart = False, SpeedAdjust = 0, SDAPinNum = 0, SCLPinNum = 1, NumI2CBytesToReceive = 0, AddressByte = None):
@@ -1058,7 +1058,7 @@ class U6(Device):
               Section 5.2.22 of the User's Guide.
         """
         command = [ 0 ] * 10
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
@@ -1069,18 +1069,18 @@ class U6(Device):
         command[7] = ClockPinNum
         #command[8] = Reserved
         command[9] = SHTOptions
-        
+
         result = self._writeRead(command, 16, [ 0xF8, 0x05, 0x39])
-        
+
         val = (result[11]*256) + result[10]
         temp = -39.60 + 0.01*val
-        
+
         val = (result[14]*256) + result[13]
         humid = -4 + 0.0405*val + -.0000028*(val*val)
         humid = (temp - 25)*(0.01 + 0.00008*val) + humid
-        
+
         return { 'StatusReg' : result[8], 'StatusCRC' : result[9], 'Temperature' : temp, 'TemperatureCRC' : result[12], 'Humidity' : humid, 'HumidityCRC' : result[15] }
-        
+
     # --------------------------- Old U6 code -------------------------------
 
     def _readCalDataBlock(self, n):
@@ -1171,7 +1171,7 @@ class U6(Device):
 
         self.calInfo.currentOutput0 = toDouble(rcvBuffer[:8])
         self.calInfo.currentOutput1 = toDouble(rcvBuffer[8:16])
-        
+
         self.calInfo.temperatureSlope = toDouble(rcvBuffer[16:24])
         self.calInfo.temperatureOffset = toDouble(rcvBuffer[24:])
 
@@ -1220,7 +1220,7 @@ class U6(Device):
 
     def binaryToCalibratedAnalogVoltage(self, gainIndex, bytesVoltage, is16Bits=False, resolutionIndex=0):
         """
-        Name: U6.binaryToCalibratedAnalogVoltage(gainIndex, bytesVoltage, 
+        Name: U6.binaryToCalibratedAnalogVoltage(gainIndex, bytesVoltage,
                                                  is16Bits = False, resolutionIndex = 0)
         Args: gainIndex, which gain index did you use?
               bytesVoltage, bytes returned from the U6
@@ -1274,7 +1274,7 @@ class U6(Device):
             bits = min(bits, 0xFFFF)
         else:
             bits = min(bits/256, 0xFF)
-        
+
         return int(max(bits, 0))
 
     def softReset(self):
@@ -1282,16 +1282,16 @@ class U6(Device):
         Name: U6.softReset()
         Args: none
         Desc: Send a soft reset.
-        
+
         >>> myU6 = U6()
         >>> myU6.softReset()
         """
         command = [ 0x00, 0x99, 0x01, 0x00 ]
         command = setChecksum8(command, 4)
-        
+
         self.write(command, False, False)
         results = self.read(4)
-        
+
         if results[3] != 0:
             raise LowlevelErrorException(results[3], "The softReset command returned an error:\n    %s" % lowlevelErrorToString(results[3]))
 
@@ -1300,19 +1300,19 @@ class U6(Device):
         Name: U6.hardReset()
         Args: none
         Desc: Send a hard reset.
-        
+
         >>> myU6 = U6()
         >>> myU6.hardReset()
         """
         command = [ 0x00, 0x99, 0x02, 0x00 ]
         command = setChecksum8(command, 4)
-        
+
         self.write(command, False, False)
         results = self.read(4)
-        
+
         if results[3] != 0:
             raise LowlevelErrorException(results[3], "The softHard command returned an error:\n    %s" % lowlevelErrorToString(results[3]))
-            
+
         self.close()
 
     def setLED(self, state):
@@ -1320,7 +1320,7 @@ class U6(Device):
         Name: U6.setLED(state)
         Args: state: 1 = On, 0 = Off
         Desc: Sets the state of the LED. (5.2.5.4 of user's guide)
-        
+
         >>> d = u6.U6()
         >>> d.setLED(0)
         ... (LED turns off) ...
@@ -1338,7 +1338,7 @@ class U6(Device):
               state, 1 = High, 0 = Low
         Desc: A convenience function to set the state of a digital I/O. Will
               also set the direction to output.
-        
+
         Example:
         >>> import u6
         >>> d = u6.U6()
@@ -1356,7 +1356,7 @@ class U6(Device):
                   20 - 22 = MIO0 - MIO2
         Desc: A convenience function to read the state of a digital I/O.  Will
               also set the direction to input.
-        
+
         Example:
         >>> import u6
         >>> d = u6.U6()
@@ -1375,7 +1375,7 @@ class U6(Device):
                   20 - 22 = MIO0 - MIO2
         Desc: A convenience function to read the state of a digital I/O.  Will
               not change the direction.
-        
+
         Example:
         >>> import u6
         >>> d = u6.U6()
@@ -1388,16 +1388,16 @@ class U6(Device):
         """
         Name: U6.getTemperature()
         Args: none
-        Desc: Reads the U6's internal temperature sensor in Kelvin. 
+        Desc: Reads the U6's internal temperature sensor in Kelvin.
               See Section 2.6.4 of the U6 User's Guide.
-        
+
         >>> myU6.getTemperature()
         299.87723471224308
         """
         if self.calInfo.nominal:
             # Read the actual calibration constants if we haven't already.
             self.getCalibrationData()
-        
+
         result = self.getFeedback(AIN24AR(14))
         return self.binaryToCalibratedAnalogTemperature(result[0]['AIN'])
 
@@ -1411,17 +1411,17 @@ class U6(Device):
               gainIndex, the gain index.  0=x1, 1=x10, 2=x100, 3=x1000,
                          15=autorange.
               settlingFactor, the settling factor.  0=Auto, 1=20us, 2=50us,
-                              3=100us, 4=200us, 5=500us, 6=1ms, 7=2ms, 8=5ms, 
+                              3=100us, 4=200us, 5=500us, 6=1ms, 7=2ms, 8=5ms,
                               9=10ms.
               differential, set to True for differential reading.  Negative
                             channel is positiveChannel+1.
         Desc: Reads an AIN and applies the calibration constants to it.
-        
+
         >>> myU6.getAIN(14)
         299.87723471224308
         """
         result = self.getFeedback(AIN24AR(positiveChannel, resolutionIndex, gainIndex, settlingFactor, differential))
-        
+
         return self.binaryToCalibratedAnalogVoltage(result[0]['GainIndex'], result[0]['AIN'], resolutionIndex = resolutionIndex)
 
     def readDefaultsConfig(self):
@@ -1432,53 +1432,53 @@ class U6(Device):
         """
         results = dict()
         defaults = self.readDefaults(0)
-        
+
         results['FIODirection'] = defaults[4]
         results['FIOState'] = defaults[5]
-        
+
         results['EIODirection'] = defaults[8]
         results['EIOState'] = defaults[9]
-        
+
         results['CIODirection'] = defaults[12]
         results['CIOState'] = defaults[13]
-        
+
         results['ConfigWriteMask'] = defaults[16]
         results['NumOfTimersEnable'] = defaults[17]
         results['CounterMask'] = defaults[18]
         results['PinOffset'] = defaults[19]
-        
+
         defaults = self.readDefaults(1)
         results['ClockSource'] = defaults[0]
         results['Divisor'] = defaults[1]
-        
+
         results['TMR0Mode'] = defaults[16]
         results['TMR0ValueL'] = defaults[17]
         results['TMR0ValueH'] = defaults[18]
-        
+
         results['TMR1Mode'] = defaults[20]
         results['TMR1ValueL'] = defaults[21]
         results['TMR1ValueH'] = defaults[22]
-        
+
         results['TMR2Mode'] = defaults[24]
         results['TMR2ValueL'] = defaults[25]
         results['TMR2ValueH'] = defaults[26]
-        
+
         results['TMR3Mode'] = defaults[28]
         results['TMR3ValueL'] = defaults[29]
         results['TMR3ValueH'] = defaults[30]
-        
+
         defaults = self.readDefaults(2)
-        
+
         results['DAC0'] = unpack( "<H", pack("BB", *defaults[16:18]) )[0]
-        
+
         results['DAC1'] = unpack( "<H", pack("BB", *defaults[20:22]) )[0]
-        
+
         defaults = self.readDefaults(3)
-        
+
         for i in range(14):
             results["AIN%sGainRes" % i] = defaults[i]
             results["AIN%sOptions" % i] = defaults[i+16]
-        
+
         return results
 
     def exportConfig(self):
@@ -1489,65 +1489,65 @@ class U6(Device):
         """
         # Make a new configuration file
         parser = ConfigParser.SafeConfigParser()
-        
+
         # Change optionxform so that options preserve their case.
         parser.optionxform = str
-        
+
         # Local Id and name
         section = "Identifiers"
         parser.add_section(section)
         parser.set(section, "Local ID", str(self.localId))
         parser.set(section, "Name", str(self.getName()))
         parser.set(section, "Device Type", str(self.devType))
-        
+
         # FIO Direction / State
         section = "FIOs"
         parser.add_section(section)
-        
+
         dirs, states = self.getFeedback( PortDirRead(), PortStateRead() )
-        
+
         for key, value in dirs.items():
             parser.set(section, "%s Directions" % key, str(value))
-            
+
         for key, value in states.items():
             parser.set(section, "%s States" % key, str(value))
-            
+
         # DACs
         section = "DACs"
         parser.add_section(section)
-        
+
         dac0 = self.readRegister(5000)
         dac0 = max(dac0, 0)
         dac0 = min(dac0, 5)
         parser.set(section, "DAC0", "%0.2f" % dac0)
-        
+
         dac1 = self.readRegister(5002)
         dac1 = max(dac1, 0)
         dac1 = min(dac1, 5)
         parser.set(section, "DAC1", "%0.2f" % dac1)
-        
+
         # Timer Clock Configuration
         section = "Timer Clock Speed Configuration"
         parser.add_section(section)
-        
+
         timerclockconfig = self.configTimerClock()
         for key, value in timerclockconfig.items():
             parser.set(section, key, str(value))
-        
+
         # Timers / Counters
         section = "Timers And Counters"
         parser.add_section(section)
-        
+
         ioconfig = self.configIO()
         for key, value in ioconfig.items():
             parser.set(section, key, str(value))
-            
-        
+
+
         for i in range(ioconfig['NumberTimersEnabled']):
             mode, value = self.readRegister(7100 + (2 * i), numReg = 2, format = ">HH")
             parser.set(section, "Timer%s Mode" % i, str(mode))
             parser.set(section, "Timer%s Value" % i, str(value))
-        
+
         return parser
 
     def loadConfig(self, configParserObj):
@@ -1557,62 +1557,62 @@ class U6(Device):
         Desc: Takes a configuration and updates the U6 to match it.
         """
         parser = configParserObj
-        
+
         # Set Identifiers:
         section = "Identifiers"
         if parser.has_section(section):
             if parser.has_option(section, "device type"):
                 if parser.getint(section, "device type") != self.devType:
                     raise Exception("Not a U6 Config file.")
-            
+
             if parser.has_option(section, "local id"):
                 self.configU6( LocalID = parser.getint(section, "local id"))
-                
+
             if parser.has_option(section, "name"):
                 self.setName( parser.get(section, "name") )
-            
+
         # Set FIOs:
         section = "FIOs"
         if parser.has_section(section):
             fiodirs = 0
             eiodirs = 0
             ciodirs = 0
-            
+
             fiostates = 0
             eiostates = 0
             ciostates = 0
-            
+
             if parser.has_option(section, "fios directions"):
                 fiodirs = parser.getint(section, "fios directions")
             if parser.has_option(section, "eios directions"):
                 eiodirs = parser.getint(section, "eios directions")
             if parser.has_option(section, "cios directions"):
                 ciodirs = parser.getint(section, "cios directions")
-            
+
             if parser.has_option(section, "fios states"):
                 fiostates = parser.getint(section, "fios states")
             if parser.has_option(section, "eios states"):
                 eiostates = parser.getint(section, "eios states")
             if parser.has_option(section, "cios states"):
                 ciostates = parser.getint(section, "cios states")
-            
+
             self.getFeedback( PortStateWrite([fiostates, eiostates, ciostates]), PortDirWrite([fiodirs, eiodirs, ciodirs]) )
-            
+
         # Set DACs:
         section = "DACs"
         if parser.has_section(section):
             if parser.has_option(section, "dac0"):
                 self.writeRegister(5000, parser.getfloat(section, "dac0"))
-            
+
             if parser.has_option(section, "dac1"):
                 self.writeRegister(5002, parser.getfloat(section, "dac1"))
-                
+
         # Set Timer Clock Configuration
         section = "Timer Clock Speed Configuration"
         if parser.has_section(section):
             if parser.has_option(section, "timerclockbase") and parser.has_option(section, "timerclockdivisor"):
                 self.configTimerClock(TimerClockBase = parser.getint(section, "timerclockbase"), TimerClockDivisor = parser.getint(section, "timerclockdivisor"))
-        
+
         # Set Timers / Counters
         section = "Timers And Counters"
         if parser.has_section(section):
@@ -1620,38 +1620,38 @@ class U6(Device):
             c0e = None
             c1e = None
             cpo = None
-            
+
             if parser.has_option(section, "NumberTimersEnabled"):
                 nte = parser.getint(section, "NumberTimersEnabled")
-            
+
             if parser.has_option(section, "TimerCounterPinOffset"):
                 cpo = parser.getint(section, "TimerCounterPinOffset")
-            
+
             if parser.has_option(section, "Counter0Enabled"):
                 c0e = parser.getboolean(section, "Counter0Enabled")
-            
+
             if parser.has_option(section, "Counter1Enabled"):
                 c1e = parser.getboolean(section, "Counter1Enabled")
-                
+
             self.configIO(NumberTimersEnabled = nte, EnableCounter1 = c1e, EnableCounter0 = c0e, TimerCounterPinOffset = cpo)
-            
-            
+
+
             mode = None
             value = None
-            
+
             for i in range(4):
                 if parser.has_option(section, "timer%i mode" % i):
                     mode = parser.getint(section, "timer%i mode" % i)
-                    
+
                     if parser.has_option(section, "timer%i value" % i):
                         value = parser.getint(section, "timer%i value" % i)
-                    
+
                     self.getFeedback( TimerConfig(i, mode, value) )
 
 class FeedbackCommand(object):
     '''
     The base FeedbackCommand class
-    
+
     Used to make Feedback easy. Make a list of these
     and call getFeedback.
     '''
@@ -1666,26 +1666,26 @@ class AIN(FeedbackCommand):
     Analog Input Feedback command
 
     AIN(PositiveChannel)
-    
-    PositiveChannel : the positive channel to use 
+
+    PositiveChannel : the positive channel to use
 
     NOTE: This function kept for compatibility. Please use
           the new AIN24 and AIN24AR.
-    
+
     returns 16-bit unsigned int sample
-    
+
     >>> d.getFeedback( u6.AIN( PositiveChannel ) )
     [ 19238 ]
     '''
     def __init__(self, PositiveChannel):
         if PositiveChannel not in _validChannels:
             raise LabJackException("Invalid Positive Channel specified")
-        
+
         self.positiveChannel = PositiveChannel
         self.cmdBytes = [ 0x01, PositiveChannel, 0 ]
 
     readLen =  2
-    
+
     def __repr__(self):
         return "<u6.AIN( PositiveChannel = %s )>" % self.positiveChannel
 
@@ -1699,12 +1699,12 @@ class AIN24(FeedbackCommand):
 
     ainCommand = AIN24(PositiveChannel, ResolutionIndex = 0, GainIndex = 0,
                        SettlingFactor = 0, Differential = False)
-    
+
     See section 5.2.5.2 of the user's guide.
-    
+
     NOTE: If you use a gain index of 15 (autorange), you should be using
-          the AIN24AR command instead. 
-    
+          the AIN24AR command instead.
+
     positiveChannel : The positive channel to use
     resolutionIndex : 0=default, 1-8 for high-speed ADC,
                       9-12 for high-res ADC on U6-Pro.
@@ -1713,9 +1713,9 @@ class AIN24(FeedbackCommand):
                      7=2ms, 8=5ms, 9=10ms.
     differential : If this bit is set, a differential reading is done where
                    the negative channel is positiveChannel+1
-    
+
     returns 24-bit unsigned int sample
-    
+
     >>> d.getFeedback( u6.AIN24(PositiveChannel, ResolutionIndex = 0,
                                 GainIndex = 0, SettlingFactor = 0,
                                 Differential = False ) )
@@ -1730,10 +1730,10 @@ class AIN24(FeedbackCommand):
         self.gainIndex = GainIndex
         self.settlingFactor = SettlingFactor
         self.differential = Differential
-        
+
         byte2 = ( ResolutionIndex & 0xf )
         byte2 = ( ( GainIndex & 0xf ) << 4 ) + byte2
-        
+
         byte3 = (int(Differential) << 7) + SettlingFactor
         self.cmdBytes = [ 0x02, PositiveChannel, byte2, byte3 ]
 
@@ -1751,28 +1751,28 @@ class AIN24AR(FeedbackCommand):
     '''
     Autorange Analog Input 24-bit Feedback command
 
-    ainARCommand = AIN24AR(0, ResolutionIndex = 0, GainIndex = 0, 
+    ainARCommand = AIN24AR(0, ResolutionIndex = 0, GainIndex = 0,
                            SettlingFactor = 0, Differential = False)
-    
+
     See section 5.2.5.3 of the user's guide
-    
+
     PositiveChannel : The positive channel to use
-    ResolutionIndex : 0=default, 1-8 for high-speed ADC, 
+    ResolutionIndex : 0=default, 1-8 for high-speed ADC,
                       9-13 for high-res ADC on U6-Pro.
     GainIndex : 0=x1, 1=x10, 2=x100, 3=x1000, 15=autorange
     SettlingFactor : 0=Auto, 1=20us, 2=50us, 3=100us, 4=200us, 5=500us, 6=1ms,
                      7=2ms, 8=5ms, 9=10ms.
     Differential : If this bit is set, a differential reading is done where
                    the negative channel is positiveChannel+1
-    
+
     returns a dictionary:
-        { 
-        'AIN' : < 24-bit binary reading >, 
+        {
+        'AIN' : < 24-bit binary reading >,
         'ResolutionIndex' : < actual resolution setting used for the reading >,
         'GainIndex' : < actual gain used for the reading >,
         'Status' : < reserved for future use >
         }
-    
+
     >>> d.getFeedback( u6.AIN24AR( PositiveChannel, ResolutionIndex = 0,
                                    GainIndex = 0, SettlingFactor = 0,
                                    Differential = False ) )
@@ -1790,7 +1790,7 @@ class AIN24AR(FeedbackCommand):
 
         byte2 = ( ResolutionIndex & 0xf )
         byte2 = ( ( GainIndex & 0xf ) << 4 ) + byte2
-        
+
         byte3 = (int(Differential) << 7) + SettlingFactor
         self.cmdBytes = [ 0x03, PositiveChannel, byte2, byte3 ]
 
@@ -1803,33 +1803,33 @@ class AIN24AR(FeedbackCommand):
         #Put it all into an integer.
         result = (input[2] << 16 ) + (input[1] << 8 ) + input[0]
         resolutionIndex = input[3] & 0xf
-        gainIndex = ( input[3] >> 4 ) & 0xf 
+        gainIndex = ( input[3] >> 4 ) & 0xf
         status = input[4]
-        
-        return { 'AIN' : result, 'ResolutionIndex' : resolutionIndex, 'GainIndex' : gainIndex, 'Status' : status }   
+
+        return { 'AIN' : result, 'ResolutionIndex' : resolutionIndex, 'GainIndex' : gainIndex, 'Status' : status }
 
 class WaitShort(FeedbackCommand):
     '''
     WaitShort Feedback command
 
     specify the number of 128us time increments to wait
-    
+
     >>> d.getFeedback( u6.WaitShort( Time ) )
     [ None ]
     '''
     def __init__(self, Time):
         self.time = Time % 256
         self.cmdBytes = [ 5, Time % 256 ]
-        
+
     def __repr__(self):
         return "<u6.WaitShort( Time = %s )>" % self.time
 
 class WaitLong(FeedbackCommand):
     '''
     WaitLong Feedback command
-    
+
     specify the number of 32ms time increments to wait
-    
+
     >>> d.getFeedback( u6.WaitLog( Time ) )
     [ None ]
     '''
@@ -1845,16 +1845,16 @@ class LED(FeedbackCommand):
     LED Toggle
 
     specify whether the LED should be on or off by truth value
-    
+
     1 or True = On, 0 or False = Off
-    
+
     >>> d.getFeedback( u6.LED( State ) )
     [ None ]
     '''
     def __init__(self, State):
         self.state = State
         self.cmdBytes = [ 9, int(bool(State)) ]
-        
+
     def __repr__(self):
         return "<u6.LED( State = %s )>" % self.state
 
@@ -1867,7 +1867,7 @@ class BitStateRead(FeedbackCommand):
 
     IONumber: 0-7=FIO, 8-15=EIO, 16-19=CIO
     return 0 or 1
-    
+
     >>> d.getFeedback( u6.BitStateRead( IONumber ) )
     [ 1 ]
     '''
@@ -1892,7 +1892,7 @@ class BitStateWrite(FeedbackCommand):
 
     IONumber: 0-7=FIO, 8-15=EIO, 16-19=CIO
     State: 0 or 1
-    
+
     >>> d.getFeedback( u6.BitStateWrite( IONumber, State ) )
     [ None ]
     '''
@@ -1900,7 +1900,7 @@ class BitStateWrite(FeedbackCommand):
         self.ioNumber = IONumber
         self.state = State
         self.cmdBytes = [ 11, (IONumber % 20) + (int(bool(State)) << 7) ]
-    
+
     def __repr__(self):
         return "<u6.BitStateWrite( IONumber = %s, State = %s )>" % self.ioNumber
 
@@ -1910,7 +1910,7 @@ class BitDirRead(FeedbackCommand):
 
     IONumber: 0-7=FIO, 8-15=EIO, 16-19=CIO
     returns 1 = Output, 0 = Input
-    
+
     >>> d.getFeedback( u6.BitDirRead( IONumber ) )
     [ 1 ]
     '''
@@ -1934,15 +1934,15 @@ class BitDirWrite(FeedbackCommand):
 
     IONumber: 0-7=FIO, 8-15=EIO, 16-19=CIO
     Direction: 1 = Output, 0 = Input
-    
+
     >>> d.getFeedback( u6.BitDirWrite( IONumber, Direction ) )
-    [ None ] 
+    [ None ]
     '''
     def __init__(self, IONumber, Direction):
         self.ioNumber = IONumber
         self.direction = Direction
         self.cmdBytes = [ 13, (IONumber % 20) + (int(bool(Direction)) << 7) ]
-        
+
     def __repr__(self):
         return "<u6.BitDirWrite( IONumber = %s, Direction = %s )>" % (self.ioNumber, self.direction)
 
@@ -1951,29 +1951,29 @@ class PortStateRead(FeedbackCommand):
     PortStateRead Feedback command
 
     Reads the state of all digital I/O.
-    
+
     >>> d.getFeedback( u6.PortStateRead() )
     [ { 'FIO' : 10, 'EIO' : 0, 'CIO' : 0 } ]
     """
     def __init__(self):
         self.cmdBytes = [ 26 ]
-        
+
     def __repr__(self):
         return "<u6.PortStateRead()>"
-        
+
     readLen = 3
-    
+
     def handle(self, input):
         return {'FIO' : input[0], 'EIO' : input[1], 'CIO' : input[2] }
 
 class PortStateWrite(FeedbackCommand):
     """
     PortStateWrite Feedback command
-    
+
     State: A list of 3 bytes representing FIO, EIO, CIO
     WriteMask: A list of 3 bytes, representing which to update.
                The Default is all ones.
-    
+
     >>> d.getFeedback( u6.PortStateWrite( State,
                                           WriteMask = [ 0xff, 0xff, 0xff] ) )
     [ None ]
@@ -1982,37 +1982,37 @@ class PortStateWrite(FeedbackCommand):
         self.state = State
         self.writeMask = WriteMask
         self.cmdBytes = [ 27 ] + WriteMask + State
-        
+
     def __repr__(self):
         return "<u6.PortStateWrite( State = %s, WriteMask = %s )>" % (self.state, self.writeMask)
-        
+
 class PortDirRead(FeedbackCommand):
     """
     PortDirRead Feedback command
     Reads the direction of all digital I/O.
-    
+
     >>> d.getFeedback( u6.PortDirRead() )
     [ { 'FIO' : 10, 'EIO' : 0, 'CIO' : 0 } ]
     """
     def __init__(self):
         self.cmdBytes = [ 28 ]
-    
+
     def __repr__(self):
         return "<u6.PortDirRead()>"
-    
+
     readLen = 3
-    
+
     def handle(self, input):
         return {'FIO' : input[0], 'EIO' : input[1], 'CIO' : input[2] }
 
 class PortDirWrite(FeedbackCommand):
     """
     PortDirWrite Feedback command
-    
+
     Direction: A list of 3 bytes representing FIO, EIO, CIO
     WriteMask: A list of 3 bytes, representing which to update. Default is all ones.
-    
-    >>> d.getFeedback( u6.PortDirWrite( Direction, 
+
+    >>> d.getFeedback( u6.PortDirWrite( Direction,
                                         WriteMask = [ 0xff, 0xff, 0xff] ) )
     [ None ]
     """
@@ -2020,19 +2020,19 @@ class PortDirWrite(FeedbackCommand):
         self.direction = Direction
         self.writeMask = WriteMask
         self.cmdBytes = [ 29 ] + WriteMask + Direction
-        
+
     def __repr__(self):
         return "<u6.PortDirWrite( Direction = %s, WriteMask = %s )>" % (self.direction, self.writeMask)
-    
+
 class DAC8(FeedbackCommand):
     '''
     8-bit DAC Feedback command
-    
+
     Controls a single analog output
 
     Dac: 0 or 1
     Value: 0-255
-    
+
     >>> d.getFeedback( u6.DAC8( Dac, Value ) )
     [ None ]
     '''
@@ -2040,18 +2040,18 @@ class DAC8(FeedbackCommand):
         self.dac = Dac
         self.value = Value % 256
         self.cmdBytes = [ 34 + (Dac % 2), Value % 256 ]
-    
+
     def __repr__(self):
         return "<u6.DAC8( Dac = %s, Value = %s )>" % (self.dac, self.value)
-        
+
 class DAC0_8(DAC8):
     """
     8-bit DAC Feedback command for DAC0
-    
+
     Controls DAC0 in 8-bit mode.
 
     Value: 0-255
-    
+
     >>> d.getFeedback( u6.DAC0_8( Value ) )
     [ None ]
     """
@@ -2064,17 +2064,17 @@ class DAC0_8(DAC8):
 class DAC1_8(DAC8):
     """
     8-bit DAC Feedback command for DAC1
-    
+
     Controls DAC1 in 8-bit mode.
 
     Value: 0-255
-    
+
     >>> d.getFeedback( u6.DAC1_8( Value ) )
     [ None ]
     """
     def __init__(self, Value):
         DAC8.__init__(self, 1, Value)
-    
+
     def __repr__(self):
         return "<u6.DAC1_8( Value = %s )>" % self.value
 
@@ -2086,7 +2086,7 @@ class DAC16(FeedbackCommand):
 
     Dac: 0 or 1
     Value: 0-65535
-    
+
     >>> d.getFeedback( u6.DAC16( Dac, Value ) )
     [ None ]
     '''
@@ -2094,55 +2094,55 @@ class DAC16(FeedbackCommand):
         self.dac = Dac
         self.value = Value
         self.cmdBytes = [ 38 + (Dac % 2), Value % 256, Value >> 8 ]
-    
+
     def __repr__(self):
         return "<u6.DAC8( Dac = %s, Value = %s )>" % (self.dac, self.value)
 
 class DAC0_16(DAC16):
     """
     16-bit DAC Feedback command for DAC0
-    
+
     Controls DAC0 in 16-bit mode.
 
     Value: 0-65535
-    
+
     >>> d.getFeedback( u6.DAC0_16( Value ) )
     [ None ]
     """
     def __init__(self, Value):
         DAC16.__init__(self, 0, Value)
-    
+
     def __repr__(self):
         return "<u6.DAC0_16( Value = %s )>" % self.value
 
 class DAC1_16(DAC16):
     """
     16-bit DAC Feedback command for DAC1
-    
+
     Controls DAC1 in 16-bit mode.
 
     Value: 0-65535
-    
+
     >>> d.getFeedback( u6.DAC1_16( Value ) )
     [ None ]
     """
     def __init__(self, Value):
         DAC16.__init__(self, 1, Value)
-        
+
     def __repr__(self):
         return "<u6.DAC1_16( Value = %s )>" % self.value
 
-        
+
 class Timer(FeedbackCommand):
     """
     For reading the value of the Timer. It provides the ability to update/reset
     a given timer, and read the timer value.
     ( Section 5.2.5.17 of the User's Guide)
-    
+
     timer: 0 to 3 for timer0 to timer3
-    
+
     UpdateReset: Set True if you want to update the value
-    
+
     Value: Only updated if the UpdateReset bit is 1.  The meaning of this
            parameter varies with the timer mode.
 
@@ -2151,7 +2151,7 @@ class Timer(FeedbackCommand):
 
     Returns an unsigned integer of the timer value, unless Mode has been
     specified and there are special return values. See Section 2.9.1 for
-    expected return values. 
+    expected return values.
 
     >>> d.getFeedback( u6.Timer( timer, UpdateReset = False, Value = 0 \
     ... , Mode = None ) )
@@ -2162,19 +2162,19 @@ class Timer(FeedbackCommand):
             raise LabJackException("Timer should be 0-3.")
         if UpdateReset and (Value is None):
             raise LabJackException("UpdateReset set but no value.")
-        
+
         self.timer = timer
         self.updateReset = UpdateReset
         self.value = Value
         self.mode = Mode
-        
+
         self.cmdBytes = [ (42 + (2*timer)), UpdateReset, Value % 256, Value >> 8 ]
-    
+
     readLen = 4
-    
+
     def __repr__(self):
         return "<u6.Timer( timer = %s, UpdateReset = %s, Value = %s, Mode = %s )>" % (self.timer, self.updateReset, self.value, self.mode)
-    
+
     def handle(self, input):
         inStr = pack('B' * len(input), *input)
         if self.mode == 8:
@@ -2191,9 +2191,9 @@ class Timer0(Timer):
     For reading the value of Timer0. It provides the ability to update/reset
     Timer0, and read the timer value.
     (Section 5.2.5.17 of the User's Guide)
-    
+
     UpdateReset: Set True if you want to update the value
-    
+
     Value: Only updated if the UpdateReset bit is 1.  The meaning of this
            parameter varies with the timer mode.
 
@@ -2206,7 +2206,7 @@ class Timer0(Timer):
     """
     def __init__(self, UpdateReset = False, Value = 0, Mode = None):
         Timer.__init__(self, 0, UpdateReset, Value, Mode)
-        
+
     def __repr__(self):
         return "<u6.Timer0( UpdateReset = %s, Value = %s, Mode = %s )>" % (self.updateReset, self.value, self.mode)
 
@@ -2216,9 +2216,9 @@ class Timer1(Timer):
     For reading the value of Timer1. It provides the ability to update/reset
     Timer1, and read the timer value.
     (Section 5.2.5.17 of the User's Guide)
-    
+
     UpdateReset: Set True if you want to update the value
-    
+
     Value: Only updated if the UpdateReset bit is 1.  The meaning of this
            parameter varies with the timer mode.
 
@@ -2231,7 +2231,7 @@ class Timer1(Timer):
     """
     def __init__(self, UpdateReset = False, Value = 0, Mode = None):
         Timer.__init__(self, 1, UpdateReset, Value, Mode)
-    
+
     def __repr__(self):
         return "<u6.Timer1( UpdateReset = %s, Value = %s, Mode = %s )>" % (self.updateReset, self.value, self.mode)
 
@@ -2241,9 +2241,9 @@ class Timer2(Timer):
     For reading the value of Timer2. It provides the ability to update/reset
     Timer2, and read the timer value.
     (Section 5.2.5.17 of the User's Guide)
-    
+
     UpdateReset: Set True if you want to update the value
-    
+
     Value: Only updated if the UpdateReset bit is 1.  The meaning of this
            parameter varies with the timer mode.
 
@@ -2256,7 +2256,7 @@ class Timer2(Timer):
     """
     def __init__(self, UpdateReset = False, Value = 0, Mode = None):
         Timer.__init__(self, 2, UpdateReset, Value, Mode)
-    
+
     def __repr__(self):
         return "<u6.Timer2( UpdateReset = %s, Value = %s, Mode = %s )>" % (self.updateReset, self.value, self.mode)
 
@@ -2266,9 +2266,9 @@ class Timer3(Timer):
     For reading the value of Timer3. It provides the ability to update/reset
     Timer3, and read the timer value.
     (Section 5.2.5.17 of the User's Guide)
-    
+
     UpdateReset: Set True if you want to update the value
-    
+
     Value: Only updated if the UpdateReset bit is 1.  The meaning of this
            parameter varies with the timer mode.
 
@@ -2281,7 +2281,7 @@ class Timer3(Timer):
     """
     def __init__(self, UpdateReset = False, Value = 0, Mode = None):
         Timer.__init__(self, 3, UpdateReset, Value, Mode)
-    
+
     def __repr__(self):
         return "<u6.Timer3( UpdateReset = %s, Value = %s, Mode = %s )>" % (self.updateReset, self.value, self.mode)
 
@@ -2290,15 +2290,15 @@ class QuadratureInputTimer(Timer):
     """
     For reading Quadrature input timers. They are special because their values
     are signed.
-    
+
     ( Section 2.9.1.8 of the User's Guide)
-    
+
     Args:
        UpdateReset: Set True if you want to reset the counter.
        Value: Set to 0, and UpdateReset to True to reset the counter.
-    
+
     Returns a signed integer.
-    
+
     >>> # Setup the two timers to be quadrature
     >>> d.getFeedback( u6.Timer0Config( 8 ), u6.Timer1Config( 8 ) )
     [None, None]
@@ -2308,7 +2308,7 @@ class QuadratureInputTimer(Timer):
     """
     def __init__(self, UpdateReset = False, Value = 0):
         Timer.__init__(self, 0, UpdateReset, Value, Mode = 8)
-        
+
     def __repr__(self):
         return "<u6.QuadratureInputTimer( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)
 
@@ -2317,16 +2317,16 @@ class TimerStopInput1(Timer1):
     """
     For reading a stop input timer. They are special because the value returns
     the current edge count and the stop value.
-    
+
     ( Section 2.9.1.9 of the User's Guide)
-    
+
     Args:
         UpdateReset: Set True if you want to update the value.
         Value: The stop value. Only updated if the UpdateReset bit is 1.
-    
+
     Returns a tuple where the first value is current edge count, and the second
     value is the stop value.
-    
+
     >>> # Setup the timer to be Stop Input
     >>> d.getFeedback( u6.Timer0Config( 9, Value = 30 ) )
     [None]
@@ -2336,7 +2336,7 @@ class TimerStopInput1(Timer1):
     """
     def __init__(self, UpdateReset = False, Value = 0):
         Timer.__init__(self, 1, UpdateReset, Value, Mode = 9)
-    
+
     def __repr__(self):
         return "<u6.TimerStopInput1( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)
 
@@ -2344,13 +2344,13 @@ class TimerStopInput1(Timer1):
 class TimerConfig(FeedbackCommand):
     """
     This IOType configures a particular timer.
-    
+
     timer: # of the timer to configure
-    
+
     TimerMode: See Section 2.9 for more information about the available modes.
-    
+
     Value: The meaning of this parameter varies with the timer mode.
-    
+
     >>> d.getFeedback( u6.TimerConfig( timer, TimerMode, Value = 0 ) )
     [ None ]
     """
@@ -2358,16 +2358,16 @@ class TimerConfig(FeedbackCommand):
         '''Creates command bytes for configuring a Timer'''
         if timer not in range(4):
             raise LabJackException("Timer should be 0-3.")
-        
+
         if TimerMode > 14 or TimerMode < 0:
             raise LabJackException("Invalid Timer Mode.")
-        
+
         self.timer = timer
         self.timerMode = TimerMode
         self.value = Value
-        
+
         self.cmdBytes = [43 + (timer * 2), TimerMode, Value % 256, Value >> 8]
-    
+
     def __repr__(self):
         return "<u6.TimerConfig( timer = %s, TimerMode = %s, Value = %s )>" % (self.timer, self.timerMode, self.value)
 
@@ -2375,17 +2375,17 @@ class TimerConfig(FeedbackCommand):
 class Timer0Config(TimerConfig):
     """
     This IOType configures Timer0.
-    
+
     TimerMode: See Section 2.9 for more information about the available modes.
-    
+
     Value: The meaning of this parameter varies with the timer mode.
-    
+
     >>> d.getFeedback( u6.Timer0Config( TimerMode, Value = 0 ) )
     [ None ]
     """
     def __init__(self, TimerMode, Value = 0):
         TimerConfig.__init__(self, 0, TimerMode, Value)
-    
+
     def __repr__(self):
         return "<u6.Timer0Config( TimerMode = %s, Value = %s )>" % (self.timerMode, self.value)
 
@@ -2393,17 +2393,17 @@ class Timer0Config(TimerConfig):
 class Timer1Config(TimerConfig):
     """
     This IOType configures Timer1.
-    
+
     TimerMode: See Section 2.9 for more information about the available modes.
-    
+
     Value: The meaning of this parameter varies with the timer mode.
-    
+
     >>> d.getFeedback( u6.Timer1Config( TimerMode, Value = 0 ) )
     [ None ]
     """
     def __init__(self, TimerMode, Value = 0):
         TimerConfig.__init__(self, 1, TimerMode, Value)
-    
+
     def __repr__(self):
         return "<u6.Timer1Config( TimerMode = %s, Value = %s )>" % (self.timerMode, self.value)
 
@@ -2411,17 +2411,17 @@ class Timer1Config(TimerConfig):
 class Timer2Config(TimerConfig):
     """
     This IOType configures Timer2.
-    
+
     TimerMode: See Section 2.9 for more information about the available modes.
-    
+
     Value: The meaning of this parameter varies with the timer mode.
-    
+
     >>> d.getFeedback( u6.Timer2Config( TimerMode, Value = 0 ) )
     [ None ]
     """
     def __init__(self, TimerMode, Value = 0):
         TimerConfig.__init__(self, 2, TimerMode, Value)
-    
+
     def __repr__(self):
         return "<u6.Timer2Config( TimerMode = %s, Value = %s )>" % (self.timerMode, self.value)
 
@@ -2429,17 +2429,17 @@ class Timer2Config(TimerConfig):
 class Timer3Config(TimerConfig):
     """
     This IOType configures Timer3.
-    
+
     TimerMode: See Section 2.9 for more information about the available modes.
-    
+
     Value: The meaning of this parameter varies with the timer mode.
-    
+
     >>> d.getFeedback( u6.Timer3Config( TimerMode, Value = 0 ) )
     [ None ]
     """
     def __init__(self, TimerMode, Value = 0):
         TimerConfig.__init__(self, 3, TimerMode, Value)
-    
+
     def __repr__(self):
         return "<u6.Timer3Config( TimerMode = %s, Value = %s )>" % (self.timerMode, self.value)
 
@@ -2455,7 +2455,7 @@ class Counter(FeedbackCommand):
 
     Returns the current count from the counter if enabled.  If reset,
     this is the value before the reset.
-    
+
     >>> d.getFeedback(u6.Counter(counter, Reset = False))
     [ 2183 ]
     '''
@@ -2484,7 +2484,7 @@ class Counter0(Counter):
 
     Returns the current count from the counter if enabled.  If reset,
     this is the value before the reset.
-    
+
     >>> d.getFeedback(u6.Counter0(Reset = False))
     [ 2183 ]
     '''

--- a/src/u6.py
+++ b/src/u6.py
@@ -42,7 +42,7 @@ def openAllU6():
     returnDict = dict()
 
     for i in range(deviceCount(6)):
-        d = U6(firstFound = False, devNumber = i+1)
+        d = U6(firstFound=False, devNumber=i + 1)
         returnDict[str(d.serialNumber)] = d
 
     return returnDict
@@ -53,7 +53,7 @@ def dumpPacket(buffer):
     Args: byte array
     Desc: Returns hex value of all bytes in the buffer
     """
-    return repr([ hex(x) for x in buffer ])
+    return repr([hex(x) for x in buffer])
 
 def getBit(n, bit):
     """
@@ -84,7 +84,7 @@ def toBitList(inbyte):
     [1, 0, 1, 0, 0, 0, 0, 0]
 
     """
-    return [ getBit(inbyte, b) for b in range(8) ]
+    return [getBit(inbyte, b) for b in range(8)]
 
 def dictAsString(d):
     """Helper function that returns a string representation of a dictionary"""
@@ -185,7 +185,7 @@ class U6(Device):
     >>> print(d.configU6())
     {'SerialNumber': 320032102, ... , 'FirmwareVersion': '1.26'}
     """
-    def __init__(self, debug = False, autoOpen = True, **kargs):
+    def __init__(self, debug=False, autoOpen=True, **kargs):
         """
         Name: U6.__init__(self, debug = False, autoOpen = True, **kargs)
         Args: debug, Do you want debug information?
@@ -193,7 +193,7 @@ class U6(Device):
               **kargs, The arguments to be passed to open.
         Desc: Your basic constructor.
         """
-        Device.__init__(self, None, devType = 6)
+        Device.__init__(self, None, devType=6)
         self.firmwareVersion = 0
         self.bootloaderVersion = 0
         self.hardwareVersion = 0
@@ -215,7 +215,7 @@ class U6(Device):
         if autoOpen:
             self.open(**kargs)
 
-    def open(self, localId = None, firstFound = True, serial = None, devNumber = None, handleOnly = False, LJSocket = None):
+    def open(self, localId=None, firstFound=True, serial=None, devNumber=None, handleOnly=False, LJSocket=None):
         """
         Name: U6.open(localId = None, firstFound = True, devNumber = None,
                       handleOnly = False, LJSocket = None)
@@ -230,9 +230,9 @@ class U6(Device):
         >>> myU6 = u6.U6(autoOpen = False)
         >>> myU6.open()
         """
-        Device.open(self, 6, firstFound = firstFound, serial = serial, localId = localId, devNumber = devNumber, handleOnly = handleOnly, LJSocket = LJSocket )
+        Device.open(self, 6, firstFound=firstFound, serial=serial, localId=localId, devNumber=devNumber, handleOnly=handleOnly, LJSocket=LJSocket)
 
-    def configU6(self, LocalID = None):
+    def configU6(self, LocalID=None):
         """
         Name: U6.configU6(LocalID = None)
         Args: LocalID, if set, will write the new value to U6
@@ -248,29 +248,29 @@ class U6(Device):
          'SerialNumber': 360005087,
          'VersionInfo': 4}
         """
-        command = [ 0 ] * 26
+        command = [0] * 26
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x0A
         command[3] = 0x08
-        #command[4]  = Checksum16 (LSB)
-        #command[5]  = Checksum16 (MSB)
+        # command[4]  = Checksum16 (LSB)
+        # command[5]  = Checksum16 (MSB)
 
         if LocalID is not None:
             command[6] = (1 << 3)
             command[8] = LocalID
 
-        #command[7] = Reserved
+        # command[7] = Reserved
 
-        #command[9-25] = Reserved
+        # command[9-25] = Reserved
         try:
             result = self._writeRead(command, 38, [0xF8, 0x10, 0x08])
         except LabJackException:
             e = sys.exc_info()[1]
             if e.errorCode is 4:
                 print("NOTE: ConfigU6 returned an error of 4. This probably means you are using U6 with a *really old* firmware. Please upgrade your U6's firmware as soon as possible.")
-                result = self._writeRead(command, 38, [0xF8, 0x10, 0x08], checkBytes = False)
+                result = self._writeRead(command, 38, [0xF8, 0x10, 0x08], checkBytes=False)
             else:
                 raise e
 
@@ -289,7 +289,7 @@ class U6(Device):
 
         return {'FirmwareVersion': self.firmwareVersion, 'BootloaderVersion': self.bootloaderVersion, 'HardwareVersion': self.hardwareVersion, 'SerialNumber': self.serialNumber, 'ProductID': self.productId, 'LocalID': self.localId, 'VersionInfo': self.versionInfo, 'DeviceName': self.deviceName}
 
-    def configIO(self, NumberTimersEnabled = None, EnableCounter1 = None, EnableCounter0 = None, TimerCounterPinOffset = None, EnableUART = None):
+    def configIO(self, NumberTimersEnabled=None, EnableCounter1=None, EnableCounter0=None, TimerCounterPinOffset=None, EnableUART=None):
         """
         Name: U6.configIO(NumberTimersEnabled = None, EnableCounter1 = None,
                           EnableCounter0 = None, TimerCounterPinOffset = None)
@@ -309,14 +309,14 @@ class U6(Device):
          'NumberTimersEnabled': 0,
          'TimerCounterPinOffset': 0}
         """
-        command = [ 0 ] * 16
+        command = [0] * 16
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x05
         command[3] = 0x0B
-        #command[4]  = Checksum16 (LSB)
-        #command[5]  = Checksum16 (MSB)
+        # command[4]  = Checksum16 (LSB)
+        # command[5]  = Checksum16 (MSB)
 
         if NumberTimersEnabled is not None:
             command[6] = 1
@@ -344,9 +344,9 @@ class U6(Device):
 
         result = self._writeRead(command, 16, [0xf8, 0x05, 0x0B])
 
-        return { 'NumberTimersEnabled' : result[8], 'Counter0Enabled' : bool(result[9] & 1), 'Counter1Enabled' : bool( (result[9] >> 1) & 1), 'TimerCounterPinOffset' : result[10] }
+        return {'NumberTimersEnabled': result[8], 'Counter0Enabled': bool(result[9] & 1), 'Counter1Enabled': bool((result[9] >> 1) & 1), 'TimerCounterPinOffset': result[10]}
 
-    def configTimerClock(self, TimerClockBase = None, TimerClockDivisor = None):
+    def configTimerClock(self, TimerClockBase=None, TimerClockDivisor=None):
         """
         Name: U6.configTimerClock(TimerClockBase = None,
                                   TimerClockDivisor = None)
@@ -362,16 +362,16 @@ class U6(Device):
         >>> myU6.configTimerClock()
         {'TimerClockDivisor': 256, 'TimerClockBase': 2}
         """
-        command = [ 0 ] * 10
+        command = [0] * 10
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
         command[3] = 0x0A
-        #command[4]  = Checksum16 (LSB)
-        #command[5]  = Checksum16 (MSB)
-        #command[6]  = Reserved
-        #command[7]  = Reserved
+        # command[4]  = Checksum16 (LSB)
+        # command[5]  = Checksum16 (MSB)
+        # command[6]  = Reserved
+        # command[7]  = Reserved
 
         if TimerClockBase is not None:
             command[8] = (1 << 7)
@@ -385,7 +385,7 @@ class U6(Device):
         divisor = result[9]
         if divisor == 0:
             divisor = 256
-        return { 'TimerClockBase' : (result[8] & 7), 'TimerClockDivisor' : divisor }
+        return {'TimerClockBase': (result[8] & 7), 'TimerClockDivisor': divisor}
 
     def _buildBuffer(self, sendBuffer, readLen, commandlist):
         for cmd in commandlist:
@@ -399,7 +399,7 @@ class U6(Device):
     def _buildFeedbackResults(self, rcvBuffer, commandlist, results, i):
         for cmd in commandlist:
             if isinstance(cmd, FeedbackCommand):
-                results.append(cmd.handle(rcvBuffer[i:i+cmd.readLen]))
+                results.append(cmd.handle(rcvBuffer[i:i + cmd.readLen]))
                 i += cmd.readLen
             elif isinstance(cmd, list):
                 self._buildFeedbackResults(rcvBuffer, cmd, results, i)
@@ -445,7 +445,7 @@ class U6(Device):
         if readLen > MAX_USB_PACKET_LENGTH:
             raise LabJackException("ERROR: The feedback command you are attempting to send would yield a response that is greater than 64 bytes ( %s bytes ). Break your commands up into separate calls to getFeedback()." % readLen)
 
-        rcvBuffer = self._writeRead(sendBuffer, readLen, [], checkBytes = False, stream = False, checksum = True)
+        rcvBuffer = self._writeRead(sendBuffer, readLen, [], checkBytes=False, stream=False, checksum=True)
 
         # Check the response for errors
         try:
@@ -455,11 +455,11 @@ class U6(Device):
                 raise LabJackException("Got incorrect command bytes")
         except LowlevelErrorException:
             if isinstance(commandlist[0], list):
-                culprit = commandlist[0][ (rcvBuffer[7] - 1) ]
+                culprit = commandlist[0][(rcvBuffer[7] - 1)]
             else:
-                culprit = commandlist[ (rcvBuffer[7] -1) ]
+                culprit = commandlist[(rcvBuffer[7] - 1)]
 
-            raise LowlevelErrorException("\nThis Command\n    %s\nreturned an error:\n    %s" %  ( culprit, lowlevelErrorToString(rcvBuffer[6]) ) )
+            raise LowlevelErrorException("\nThis Command\n    %s\nreturned an error:\n    %s" % (culprit, lowlevelErrorToString(rcvBuffer[6])))
 
         results = []
         i = 9
@@ -480,25 +480,25 @@ class U6(Device):
 
         NOTE: Do not call this function while streaming.
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
         command[3] = 0x2A
         if ReadCal:
             command[3] = 0x2D
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = 0x00
         command[7] = BlockNum
 
-        result = self._writeRead(command, 40, [ 0xF8, 0x11, command[3] ])
+        result = self._writeRead(command, 40, [0xF8, 0x11, command[3]])
 
         return result[8:]
 
     def readCal(self, BlockNum):
-        return self.readMem(BlockNum, ReadCal = True)
+        return self.readMem(BlockNum, ReadCal=True)
 
     def writeMem(self, BlockNum, Data, WriteCal=False):
         """
@@ -518,16 +518,16 @@ class U6(Device):
         if not isinstance(Data, list):
             raise LabJackException("Data must be a list of bytes")
 
-        command = [ 0 ] * 40
+        command = [0] * 40
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x11
         command[3] = 0x28
         if WriteCal:
             command[3] = 0x2B
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = 0x00
         command[7] = BlockNum
         command[8:] = Data
@@ -535,7 +535,7 @@ class U6(Device):
         self._writeRead(command, 8, [0xF8, 0x01, command[3]])
 
     def writeCal(self, BlockNum, Data):
-        return self.writeMem(BlockNum, Data, WriteCal = True)
+        return self.writeMem(BlockNum, Data, WriteCal=True)
 
     def eraseMem(self, EraseCal=False):
         """
@@ -554,32 +554,32 @@ class U6(Device):
             raise LabJackException("EraseCal must be a Boolean value (True or False).")
 
         if EraseCal:
-            command = [ 0 ] * 8
+            command = [0] * 8
 
-            #command[0] = Checksum8
+            # command[0] = Checksum8
             command[1] = 0xF8
             command[2] = 0x01
             command[3] = 0x2C
-            #command[4] = Checksum16 (LSB)
-            #command[5] = Checksum16 (MSB)
+            # command[4] = Checksum16 (LSB)
+            # command[5] = Checksum16 (MSB)
             command[6] = 0x4C
             command[7] = 0x6C
         else:
-            command = [ 0 ] * 6
+            command = [0] * 6
 
-            #command[0] = Checksum8
+            # command[0] = Checksum8
             command[1] = 0xF8
             command[2] = 0x00
             command[3] = 0x29
-            #command[4] = Checksum16 (LSB)
-            #command[5] = Checksum16 (MSB)
+            # command[4] = Checksum16 (LSB)
+            # command[5] = Checksum16 (MSB)
 
         self._writeRead(command, 8, [0xF8, 0x01, command[3]])
 
     def eraseCal(self):
         return self.eraseMem(EraseCal=True)
 
-    def streamConfig(self, NumChannels = 1, ResolutionIndex = 0, SamplesPerPacket = 25, SettlingFactor = 0, InternalStreamClockFrequency = 0, DivideClockBy256 = False, ScanInterval = 1, ChannelNumbers = [0], ChannelOptions = [0], ScanFrequency = None, SampleFrequency = None):
+    def streamConfig(self, NumChannels=1, ResolutionIndex=0, SamplesPerPacket=25, SettlingFactor=0, InternalStreamClockFrequency=0, DivideClockBy256=False, ScanInterval=1, ChannelNumbers=[0], ChannelOptions=[0], ScanFrequency=None, SampleFrequency=None):
         """
         Name: U6.streamConfig(NumChannels = 1, ResolutionIndex = 0,
                               SamplesPerPacket = 25, SettlingFactor = 0,
@@ -647,17 +647,17 @@ class U6(Device):
         SamplesPerPacket = int(SamplesPerPacket)
         SamplesPerPacket = min(SamplesPerPacket, 25)
 
-        command = [0] * (14 + NumChannels*2)
-        #command[0] = Checksum8
+        command = [0] * (14 + NumChannels * 2)
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = NumChannels + 4
         command[3] = 0x11
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = NumChannels
         command[7] = ResolutionIndex
         command[8] = SamplesPerPacket
-        #command[9] = Reserved
+        # command[9] = Reserved
         command[10] = SettlingFactor
         command[11] = (InternalStreamClockFrequency & 1) << 3
         if DivideClockBy256:
@@ -665,8 +665,8 @@ class U6(Device):
         command[12] = ScanInterval & 0xFF
         command[13] = (ScanInterval >> 8) & 0xFF
         for i in range(NumChannels):
-            command[14+(i*2)] = ChannelNumbers[i]
-            command[15+(i*2)] = ChannelOptions[i]
+            command[14 + (i * 2)] = ChannelNumbers[i]
+            command[15 + (i * 2)] = ChannelOptions[i]
 
         self._writeRead(command, 8, [0xF8, 0x01, 0x11])
 
@@ -690,10 +690,10 @@ class U6(Device):
             # limit to one packet
             self.packetsPerRequest = 1
         else:
-            self.packetsPerRequest = max(1, int(freq/SamplesPerPacket))
+            self.packetsPerRequest = max(1, int(freq / SamplesPerPacket))
             self.packetsPerRequest = min(self.packetsPerRequest, 48)
 
-    def processStreamData(self, result, numBytes = None):
+    def processStreamData(self, result, numBytes=None):
         """
         Name: U6.processStreamData(result, numPackets = None)
         Args: result, the string returned from streamData()
@@ -724,7 +724,7 @@ class U6(Device):
                 else:
                     value = unpack('<H', sample)[0]
                     gainIndex = (self.streamChannelOptions[j] >> 4) & 0x3
-                    value = self.binaryToCalibratedAnalogVoltage(gainIndex, value, is16Bits = True, resolutionIndex = 1)
+                    value = self.binaryToCalibratedAnalogVoltage(gainIndex, value, is16Bits=True, resolutionIndex=1)
 
                 returnDict["AIN%s" % self.streamChannelNumbers[j]].append(value)
 
@@ -734,7 +734,7 @@ class U6(Device):
 
         return returnDict
 
-    def watchdog(self, Write = False, ResetOnTimeout = False, SetDIOStateOnTimeout = False, TimeoutPeriod = 60, DIOState = 0, DIONumber = 0):
+    def watchdog(self, Write=False, ResetOnTimeout=False, SetDIOStateOnTimeout=False, TimeoutPeriod=60, DIOState=0, DIONumber=0):
         """
         Name: U6.watchdog(Write = False, ResetOnTimeout = False,
                           SetDIOStateOnTimeout = False, TimeoutPeriod = 60,
@@ -747,14 +747,14 @@ class U6(Device):
               DIONumber, which DIO to set.
         Desc: Controls a firmware based watchdog timer.
         """
-        command = [ 0 ] * 16
+        command = [0] * 16
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x05
         command[3] = 0x09
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         if Write:
             command[6] = 1
         if ResetOnTimeout:
@@ -765,10 +765,10 @@ class U6(Device):
         t = pack("<H", TimeoutPeriod)
         command[8] = ord(t[0])
         command[9] = ord(t[1])
-        command[10] = ((DIOState & 1 ) << 7)
+        command[10] = ((DIOState & 1) << 7)
         command[10] |= (DIONumber & 0xf)
 
-        result = self._writeRead(command, 16, [ 0xF8, 0x05, 0x09])
+        result = self._writeRead(command, 16, [0xF8, 0x05, 0x09])
 
         watchdogStatus = {}
 
@@ -796,11 +796,11 @@ class U6(Device):
         else:
             watchdogStatus['DIOState'] = 0
 
-        watchdogStatus['DIONumber'] = ( result[10] & 15 )
+        watchdogStatus['DIONumber'] = (result[10] & 15)
 
         return watchdogStatus
 
-    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 0, CLKPinNum = 1, MISOPinNum = 2, MOSIPinNum = 3, CSPINNum = None):
+    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig=False, SPIMode='A', SPIClockFactor=0, CSPinNum=0, CLKPinNum=1, MISOPinNum=2, MOSIPinNum=3, CSPINNum=None):
         """
         Name: U6.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
                      SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 0,
@@ -835,19 +835,19 @@ class U6(Device):
         numSPIBytes = len(SPIBytes)
 
         oddPacket = False
-        if numSPIBytes%2 != 0:
+        if numSPIBytes % 2 != 0:
             SPIBytes.append(0)
             numSPIBytes = numSPIBytes + 1
             oddPacket = True
 
-        command = [ 0 ] * (13 + numSPIBytes)
+        command = [0] * (13 + numSPIBytes)
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 4 + (numSPIBytes/2)
+        command[2] = 4 + (numSPIBytes / 2)
         command[3] = 0x3A
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
 
         if AutoCS:
             command[6] |= (1 << 7)
@@ -862,7 +862,7 @@ class U6(Device):
         command[6] |= modeIndex
 
         command[7] = SPIClockFactor
-        #command[8] = Reserved
+        # command[8] = Reserved
         command[9] = CSPinNum
         command[10] = CLKPinNum
         command[11] = MISOPinNum
@@ -873,14 +873,14 @@ class U6(Device):
 
         command[14:] = SPIBytes
 
-        result = self._writeRead(command, 8+numSPIBytes, [ 0xF8, 1+(numSPIBytes/2), 0x3A ])
+        result = self._writeRead(command, 8 + numSPIBytes, [0xF8, 1 + (numSPIBytes / 2), 0x3A])
 
         if result[6] != 0:
             raise LowlevelErrorException(result[6], "The spi command returned an error:\n    %s" % lowlevelErrorToString(result[6]))
 
-        return { 'NumSPIBytesTransferred' : result[7], 'SPIBytes' : result[8:] }
+        return {'NumSPIBytesTransferred': result[7], 'SPIBytes': result[8:]}
 
-    def asynchConfig(self, Update = True, UARTEnable = True, DesiredBaud = None, BaudFactor = 63036):
+    def asynchConfig(self, Update=True, UARTEnable=True, DesiredBaud=None, BaudFactor=63036):
         """
         Name: U6.asynchConfig(Update = True, UARTEnable = True,
                               DesiredBaud = None, BaudFactor = 63036)
@@ -895,24 +895,24 @@ class U6(Device):
         """
 
         if UARTEnable:
-            self.configIO(EnableUART = True)
+            self.configIO(EnableUART=True)
 
-        command = [ 0 ] * 10
+        command = [0] * 10
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
         command[3] = 0x14
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #commmand[6] = 0x00
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # commmand[6] = 0x00
         if Update:
             command[7] = (1 << 7)
         if UARTEnable:
             command[7] |= (1 << 6)
 
         if DesiredBaud is not None:
-            BaudFactor = (2**16) - 48000000/(2 * DesiredBaud)
+            BaudFactor = (2**16) - 48000000 / (2 * DesiredBaud)
 
         t = pack("<H", BaudFactor)
         command[8] = ord(t[0])
@@ -934,42 +934,42 @@ class U6(Device):
         numBytes = len(AsynchBytes)
 
         oddPacket = False
-        if numBytes%2 != 0:
+        if numBytes % 2 != 0:
             oddPacket = True
             AsynchBytes.append(0)
             numBytes = numBytes + 1
 
-        command = [ 0 ] * (8+numBytes)
-        #command[0] = Checksum8
+        command = [0] * (8 + numBytes)
+        # command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 1 + (numBytes/2)
+        command[2] = 1 + (numBytes / 2)
         command[3] = 0x15
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #commmand[6] = 0x00
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # commmand[6] = 0x00
         command[7] = numBytes
         if oddPacket:
-            command[7] = numBytes-1
+            command[7] = numBytes - 1
         command[8:] = AsynchBytes
 
-        result = self._writeRead(command, 10, [ 0xF8, 0x02, 0x15])
+        result = self._writeRead(command, 10, [0xF8, 0x02, 0x15])
 
-        return { 'NumAsynchBytesSent' : result[7], 'NumAsynchBytesInRXBuffer' : result[8] }
+        return {'NumAsynchBytesSent': result[7], 'NumAsynchBytesInRXBuffer': result[8]}
 
-    def asynchRX(self, Flush = False):
+    def asynchRX(self, Flush=False):
         """
         Name: U6.asynchTX(AsynchBytes)
         Args: Flush, If True, empties the entire 256-byte RX buffer.
         Desc: Sends bytes to the U6 UART which will be sent asynchronously
               on the transmit line. Section 5.2.20 of the User's Guide.
         """
-        command = [ 0, 0xF8, 0x01, 0x16, 0, 0, 0, int(Flush)]
+        command = [0, 0xF8, 0x01, 0x16, 0, 0, 0, int(Flush)]
 
-        result = self._writeRead(command, 40, [ 0xF8, 0x11, 0x16 ])
+        result = self._writeRead(command, 40, [0xF8, 0x11, 0x16])
 
-        return { 'NumAsynchBytesInRXBuffer' : result[7], 'AsynchBytes' : result[8:] }
+        return {'NumAsynchBytesInRXBuffer': result[7], 'AsynchBytes': result[8:]}
 
-    def i2c(self, Address, I2CBytes, EnableClockStretching = False, NoStopWhenRestarting = False, ResetAtStart = False, SpeedAdjust = 0, SDAPinNum = 0, SCLPinNum = 1, NumI2CBytesToReceive = 0, AddressByte = None):
+    def i2c(self, Address, I2CBytes, EnableClockStretching=False, NoStopWhenRestarting=False, ResetAtStart=False, SpeedAdjust=0, SDAPinNum=0, SCLPinNum=1, NumI2CBytesToReceive=0, AddressByte=None):
         """
         Name: U6.i2c(Address, I2CBytes,
                      EnableClockStretching = False, NoStopWhenRestarting = False,
@@ -999,13 +999,13 @@ class U6(Device):
             I2CBytes.append(0)
             numBytes = numBytes + 1
 
-        command = [0] * (14+numBytes)
-        #command[0] = Checksum8
+        command = [0] * (14 + numBytes)
+        # command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 4 + (numBytes//2)
+        command[2] = 4 + (numBytes // 2)
         command[3] = 0x3B
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         if EnableClockStretching:
             command[6] |= (1 << 3)
         if NoStopWhenRestarting:
@@ -1021,7 +1021,7 @@ class U6(Device):
             command[10] = AddressByte
         else:
             command[10] = Address << 1
-        #command[11] = Reserved
+        # command[11] = Reserved
         command[12] = numBytes
         if oddPacket:
             command[12] = numBytes - 1
@@ -1033,7 +1033,7 @@ class U6(Device):
             NumI2CBytesToReceive = NumI2CBytesToReceive + 1
             oddResponse = True
 
-        result = self._writeRead(command, (12 + NumI2CBytesToReceive), [0xF8, (3 + (NumI2CBytesToReceive/2)), 0x3B])
+        result = self._writeRead(command, (12 + NumI2CBytesToReceive), [0xF8, (3 + (NumI2CBytesToReceive / 2)), 0x3B])
 
         if NumI2CBytesToReceive != 0:
             if oddResponse:
@@ -1043,7 +1043,7 @@ class U6(Device):
         else:
             return {'AckArray': result[8:12]}
 
-    def sht1x(self, DataPinNum = 0, ClockPinNum = 1, SHTOptions = 0xc0):
+    def sht1x(self, DataPinNum=0, ClockPinNum=1, SHTOptions=0xc0):
         """
         Name: U6.sht1x(DataPinNum = 0, ClockPinNum = 1, SHTOptions = 0xc0)
         Args: DataPinNum, Which pin is the Data line
@@ -1057,29 +1057,29 @@ class U6(Device):
         Desc: Reads temperature and humidity from a Sensirion SHT1X sensor.
               Section 5.2.22 of the User's Guide.
         """
-        command = [ 0 ] * 10
+        command = [0] * 10
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
         command[3] = 0x39
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = DataPinNum
         command[7] = ClockPinNum
-        #command[8] = Reserved
+        # command[8] = Reserved
         command[9] = SHTOptions
 
-        result = self._writeRead(command, 16, [ 0xF8, 0x05, 0x39])
+        result = self._writeRead(command, 16, [0xF8, 0x05, 0x39])
 
-        val = (result[11]*256) + result[10]
-        temp = -39.60 + 0.01*val
+        val = (result[11] * 256) + result[10]
+        temp = -39.60 + 0.01 * val
 
-        val = (result[14]*256) + result[13]
-        humid = -4 + 0.0405*val + -.0000028*(val*val)
-        humid = (temp - 25)*(0.01 + 0.00008*val) + humid
+        val = (result[14] * 256) + result[13]
+        humid = -4 + 0.0405 * val + -.0000028 * (val * val)
+        humid = (temp - 25) * (0.01 + 0.00008 * val) + humid
 
-        return { 'StatusReg' : result[8], 'StatusCRC' : result[9], 'Temperature' : temp, 'TemperatureCRC' : result[12], 'Humidity' : humid, 'HumidityCRC' : result[15] }
+        return {'StatusReg': result[8], 'StatusCRC': result[9], 'Temperature': temp, 'TemperatureCRC': result[12], 'Humidity': humid, 'HumidityCRC': result[15]}
 
     # --------------------------- Old U6 code -------------------------------
 
@@ -1089,8 +1089,8 @@ class U6(Device):
         """
         sendBuffer = [0] * 8
         sendBuffer[1] = 0xF8  # command byte
-        sendBuffer[2] = 0x01  #  number of data words
-        sendBuffer[3] = 0x2D  #  extended command number
+        sendBuffer[2] = 0x01  # number of data words
+        sendBuffer[3] = 0x2D  # extended command number
         sendBuffer[6] = 0x00
         sendBuffer[7] = n     # Blocknum = 0
         self.write(sendBuffer)
@@ -1230,17 +1230,17 @@ class U6(Device):
         Desc: Converts binary voltage to an analog value.
         """
         if not is16Bits:
-            bits = float(bytesVoltage)/256
+            bits = float(bytesVoltage) / 256
         else:
             bits = float(bytesVoltage)
 
         if self.isPro and (resolutionIndex > 8 or resolutionIndex == 0):
-            #Use hi-res calibration constants
+            # Use hi-res calibration constants
             center = self.calInfo.proAinCenter[gainIndex]
             negSlope = self.calInfo.proAinNegSlope[gainIndex]
             posSlope = self.calInfo.proAinSlope[gainIndex]
         else:
-            #Use normal calibration constants
+            # Use normal calibration constants
             center = self.calInfo.ainCenter[gainIndex]
             negSlope = self.calInfo.ainNegSlope[gainIndex]
             posSlope = self.calInfo.ainSlope[gainIndex]
@@ -1260,7 +1260,7 @@ class U6(Device):
         voltage = self.binaryToCalibratedAnalogVoltage(0, bytesTemperature, is16Bits, 1)
         return self.calInfo.temperatureSlope * float(voltage) + self.calInfo.temperatureOffset
 
-    def voltageToDACBits(self, volts, dacNumber = 0, is16Bits = False):
+    def voltageToDACBits(self, volts, dacNumber=0, is16Bits=False):
         """
         Name: U6.voltageToDACBits(volts, dacNumber = 0, is16Bits = False)
         Args: volts, the voltage you would like to set the DAC to.
@@ -1269,11 +1269,11 @@ class U6(Device):
         Desc: Takes a voltage, and turns it into the bits needed for the DAC
               Feedback commands.
         """
-        bits = ( volts * self.calInfo.dacSlope[dacNumber] ) + self.calInfo.dacOffset[dacNumber]
+        bits = (volts * self.calInfo.dacSlope[dacNumber]) + self.calInfo.dacOffset[dacNumber]
         if is16Bits:
             bits = min(bits, 0xFFFF)
         else:
-            bits = min(bits/256, 0xFF)
+            bits = min(bits / 256, 0xFF)
 
         return int(max(bits, 0))
 
@@ -1286,7 +1286,7 @@ class U6(Device):
         >>> myU6 = U6()
         >>> myU6.softReset()
         """
-        command = [ 0x00, 0x99, 0x01, 0x00 ]
+        command = [0x00, 0x99, 0x01, 0x00]
         command = setChecksum8(command, 4)
 
         self.write(command, False, False)
@@ -1304,7 +1304,7 @@ class U6(Device):
         >>> myU6 = U6()
         >>> myU6.hardReset()
         """
-        command = [ 0x00, 0x99, 0x02, 0x00 ]
+        command = [0x00, 0x99, 0x02, 0x00]
         command = setChecksum8(command, 4)
 
         self.write(command, False, False)
@@ -1327,7 +1327,7 @@ class U6(Device):
         """
         self.getFeedback(LED(state))
 
-    def setDOState(self, ioNum, state = 1):
+    def setDOState(self, ioNum, state=1):
         """
         Name: U6.setDOState(ioNum, state = 1)
         Args: ioNum, which digital I/O to change
@@ -1422,7 +1422,7 @@ class U6(Device):
         """
         result = self.getFeedback(AIN24AR(positiveChannel, resolutionIndex, gainIndex, settlingFactor, differential))
 
-        return self.binaryToCalibratedAnalogVoltage(result[0]['GainIndex'], result[0]['AIN'], resolutionIndex = resolutionIndex)
+        return self.binaryToCalibratedAnalogVoltage(result[0]['GainIndex'], result[0]['AIN'], resolutionIndex=resolutionIndex)
 
     def readDefaultsConfig(self):
         """
@@ -1469,15 +1469,15 @@ class U6(Device):
 
         defaults = self.readDefaults(2)
 
-        results['DAC0'] = unpack( "<H", pack("BB", *defaults[16:18]) )[0]
+        results['DAC0'] = unpack("<H", pack("BB", *defaults[16:18]))[0]
 
-        results['DAC1'] = unpack( "<H", pack("BB", *defaults[20:22]) )[0]
+        results['DAC1'] = unpack("<H", pack("BB", *defaults[20:22]))[0]
 
         defaults = self.readDefaults(3)
 
         for i in range(14):
             results["AIN%sGainRes" % i] = defaults[i]
-            results["AIN%sOptions" % i] = defaults[i+16]
+            results["AIN%sOptions" % i] = defaults[i + 16]
 
         return results
 
@@ -1504,7 +1504,7 @@ class U6(Device):
         section = "FIOs"
         parser.add_section(section)
 
-        dirs, states = self.getFeedback( PortDirRead(), PortStateRead() )
+        dirs, states = self.getFeedback(PortDirRead(), PortStateRead())
 
         for key, value in dirs.items():
             parser.set(section, "%s Directions" % key, str(value))
@@ -1544,7 +1544,7 @@ class U6(Device):
 
 
         for i in range(ioconfig['NumberTimersEnabled']):
-            mode, value = self.readRegister(7100 + (2 * i), numReg = 2, format = ">HH")
+            mode, value = self.readRegister(7100 + (2 * i), numReg=2, format=">HH")
             parser.set(section, "Timer%s Mode" % i, str(mode))
             parser.set(section, "Timer%s Value" % i, str(value))
 
@@ -1566,10 +1566,10 @@ class U6(Device):
                     raise Exception("Not a U6 Config file.")
 
             if parser.has_option(section, "local id"):
-                self.configU6( LocalID = parser.getint(section, "local id"))
+                self.configU6(LocalID=parser.getint(section, "local id"))
 
             if parser.has_option(section, "name"):
-                self.setName( parser.get(section, "name") )
+                self.setName(parser.get(section, "name"))
 
         # Set FIOs:
         section = "FIOs"
@@ -1596,7 +1596,7 @@ class U6(Device):
             if parser.has_option(section, "cios states"):
                 ciostates = parser.getint(section, "cios states")
 
-            self.getFeedback( PortStateWrite([fiostates, eiostates, ciostates]), PortDirWrite([fiodirs, eiodirs, ciodirs]) )
+            self.getFeedback(PortStateWrite([fiostates, eiostates, ciostates]), PortDirWrite([fiodirs, eiodirs, ciodirs]))
 
         # Set DACs:
         section = "DACs"
@@ -1611,7 +1611,7 @@ class U6(Device):
         section = "Timer Clock Speed Configuration"
         if parser.has_section(section):
             if parser.has_option(section, "timerclockbase") and parser.has_option(section, "timerclockdivisor"):
-                self.configTimerClock(TimerClockBase = parser.getint(section, "timerclockbase"), TimerClockDivisor = parser.getint(section, "timerclockdivisor"))
+                self.configTimerClock(TimerClockBase=parser.getint(section, "timerclockbase"), TimerClockDivisor=parser.getint(section, "timerclockdivisor"))
 
         # Set Timers / Counters
         section = "Timers And Counters"
@@ -1633,7 +1633,7 @@ class U6(Device):
             if parser.has_option(section, "Counter1Enabled"):
                 c1e = parser.getboolean(section, "Counter1Enabled")
 
-            self.configIO(NumberTimersEnabled = nte, EnableCounter1 = c1e, EnableCounter0 = c0e, TimerCounterPinOffset = cpo)
+            self.configIO(NumberTimersEnabled=nte, EnableCounter1=c1e, EnableCounter0=c0e, TimerCounterPinOffset=cpo)
 
 
             mode = None
@@ -1646,7 +1646,7 @@ class U6(Device):
                     if parser.has_option(section, "timer%i value" % i):
                         value = parser.getint(section, "timer%i value" % i)
 
-                    self.getFeedback( TimerConfig(i, mode, value) )
+                    self.getFeedback(TimerConfig(i, mode, value))
 
 class FeedbackCommand(object):
     '''
@@ -1682,9 +1682,9 @@ class AIN(FeedbackCommand):
             raise LabJackException("Invalid Positive Channel specified")
 
         self.positiveChannel = PositiveChannel
-        self.cmdBytes = [ 0x01, PositiveChannel, 0 ]
+        self.cmdBytes = [0x01, PositiveChannel, 0]
 
-    readLen =  2
+    readLen = 2
 
     def __repr__(self):
         return "<u6.AIN( PositiveChannel = %s )>" % self.positiveChannel
@@ -1721,7 +1721,7 @@ class AIN24(FeedbackCommand):
                                 Differential = False ) )
     [ 193847 ]
     '''
-    def __init__(self, PositiveChannel, ResolutionIndex = 0, GainIndex = 0, SettlingFactor = 0, Differential = False):
+    def __init__(self, PositiveChannel, ResolutionIndex=0, GainIndex=0, SettlingFactor=0, Differential=False):
         if PositiveChannel not in _validChannels:
             raise LabJackException("Invalid Positive Channel specified")
 
@@ -1731,20 +1731,20 @@ class AIN24(FeedbackCommand):
         self.settlingFactor = SettlingFactor
         self.differential = Differential
 
-        byte2 = ( ResolutionIndex & 0xf )
-        byte2 = ( ( GainIndex & 0xf ) << 4 ) + byte2
+        byte2 = (ResolutionIndex & 0xf)
+        byte2 = ((GainIndex & 0xf) << 4) + byte2
 
         byte3 = (int(Differential) << 7) + SettlingFactor
-        self.cmdBytes = [ 0x02, PositiveChannel, byte2, byte3 ]
+        self.cmdBytes = [0x02, PositiveChannel, byte2, byte3]
 
     def __repr__(self):
         return "<u6.AIN24( PositiveChannel = %s, ResolutionIndex = %s, GainIndex = %s, SettlingFactor = %s, Differential = %s )>" % (self.positiveChannel, self.resolutionIndex, self.gainIndex, self.settlingFactor, self.differential)
 
-    readLen =  3
+    readLen = 3
 
     def handle(self, input):
-        #Put it all into an integer.
-        result = (input[2] << 16 ) + (input[1] << 8 ) + input[0]
+        # Put it all into an integer.
+        result = (input[2] << 16) + (input[1] << 8) + input[0]
         return result
 
 class AIN24AR(FeedbackCommand):
@@ -1778,7 +1778,7 @@ class AIN24AR(FeedbackCommand):
                                    Differential = False ) )
     { 'AIN' : 193847, 'ResolutionIndex' : 0, 'GainIndex' : 0, 'Status' : 0 }
     '''
-    def __init__(self, PositiveChannel, ResolutionIndex = 0, GainIndex = 0, SettlingFactor = 0, Differential = False):
+    def __init__(self, PositiveChannel, ResolutionIndex=0, GainIndex=0, SettlingFactor=0, Differential=False):
         if PositiveChannel not in _validChannels:
             raise LabJackException("Invalid Positive Channel specified")
 
@@ -1788,25 +1788,25 @@ class AIN24AR(FeedbackCommand):
         self.settlingFactor = SettlingFactor
         self.differential = Differential
 
-        byte2 = ( ResolutionIndex & 0xf )
-        byte2 = ( ( GainIndex & 0xf ) << 4 ) + byte2
+        byte2 = (ResolutionIndex & 0xf)
+        byte2 = ((GainIndex & 0xf) << 4) + byte2
 
         byte3 = (int(Differential) << 7) + SettlingFactor
-        self.cmdBytes = [ 0x03, PositiveChannel, byte2, byte3 ]
+        self.cmdBytes = [0x03, PositiveChannel, byte2, byte3]
 
     def __repr__(self):
         return "<u6.AIN24AR( PositiveChannel = %s, ResolutionIndex = %s, GainIndex = %s, SettlingFactor = %s, Differential = %s )>" % (self.positiveChannel, self.resolutionIndex, self.gainIndex, self.settlingFactor, self.differential)
 
-    readLen =  5
+    readLen = 5
 
     def handle(self, input):
-        #Put it all into an integer.
-        result = (input[2] << 16 ) + (input[1] << 8 ) + input[0]
+        # Put it all into an integer.
+        result = (input[2] << 16) + (input[1] << 8) + input[0]
         resolutionIndex = input[3] & 0xf
-        gainIndex = ( input[3] >> 4 ) & 0xf
+        gainIndex = (input[3] >> 4) & 0xf
         status = input[4]
 
-        return { 'AIN' : result, 'ResolutionIndex' : resolutionIndex, 'GainIndex' : gainIndex, 'Status' : status }
+        return {'AIN': result, 'ResolutionIndex': resolutionIndex, 'GainIndex': gainIndex, 'Status': status}
 
 class WaitShort(FeedbackCommand):
     '''
@@ -1819,7 +1819,7 @@ class WaitShort(FeedbackCommand):
     '''
     def __init__(self, Time):
         self.time = Time % 256
-        self.cmdBytes = [ 5, Time % 256 ]
+        self.cmdBytes = [5, Time % 256]
 
     def __repr__(self):
         return "<u6.WaitShort( Time = %s )>" % self.time
@@ -1835,7 +1835,7 @@ class WaitLong(FeedbackCommand):
     '''
     def __init__(self, Time):
         self.time = Time
-        self.cmdBytes = [ 6, Time % 256 ]
+        self.cmdBytes = [6, Time % 256]
 
     def __repr__(self):
         return "<u6.WaitLog( Time = %s )>" % self.time
@@ -1853,7 +1853,7 @@ class LED(FeedbackCommand):
     '''
     def __init__(self, State):
         self.state = State
-        self.cmdBytes = [ 9, int(bool(State)) ]
+        self.cmdBytes = [9, int(bool(State))]
 
     def __repr__(self):
         return "<u6.LED( State = %s )>" % self.state
@@ -1873,7 +1873,7 @@ class BitStateRead(FeedbackCommand):
     '''
     def __init__(self, IONumber):
         self.ioNumber = IONumber
-        self.cmdBytes = [ 10, IONumber % 20 ]
+        self.cmdBytes = [10, IONumber % 20]
 
     def __repr__(self):
         return "<u6.BitStateRead( IONumber = %s )>" % self.ioNumber
@@ -1899,7 +1899,7 @@ class BitStateWrite(FeedbackCommand):
     def __init__(self, IONumber, State):
         self.ioNumber = IONumber
         self.state = State
-        self.cmdBytes = [ 11, (IONumber % 20) + (int(bool(State)) << 7) ]
+        self.cmdBytes = [11, (IONumber % 20) + (int(bool(State)) << 7)]
 
     def __repr__(self):
         return "<u6.BitStateWrite( IONumber = %s, State = %s )>" % self.ioNumber
@@ -1916,7 +1916,7 @@ class BitDirRead(FeedbackCommand):
     '''
     def __init__(self, IONumber):
         self.ioNumber = IONumber
-        self.cmdBytes = [ 12, IONumber % 20 ]
+        self.cmdBytes = [12, IONumber % 20]
 
     def __repr__(self):
         return "<u6.BitDirRead( IONumber = %s )>" % self.ioNumber
@@ -1941,7 +1941,7 @@ class BitDirWrite(FeedbackCommand):
     def __init__(self, IONumber, Direction):
         self.ioNumber = IONumber
         self.direction = Direction
-        self.cmdBytes = [ 13, (IONumber % 20) + (int(bool(Direction)) << 7) ]
+        self.cmdBytes = [13, (IONumber % 20) + (int(bool(Direction)) << 7)]
 
     def __repr__(self):
         return "<u6.BitDirWrite( IONumber = %s, Direction = %s )>" % (self.ioNumber, self.direction)
@@ -1956,7 +1956,7 @@ class PortStateRead(FeedbackCommand):
     [ { 'FIO' : 10, 'EIO' : 0, 'CIO' : 0 } ]
     """
     def __init__(self):
-        self.cmdBytes = [ 26 ]
+        self.cmdBytes = [26]
 
     def __repr__(self):
         return "<u6.PortStateRead()>"
@@ -1964,7 +1964,7 @@ class PortStateRead(FeedbackCommand):
     readLen = 3
 
     def handle(self, input):
-        return {'FIO' : input[0], 'EIO' : input[1], 'CIO' : input[2] }
+        return {'FIO': input[0], 'EIO': input[1], 'CIO': input[2]}
 
 class PortStateWrite(FeedbackCommand):
     """
@@ -1978,10 +1978,10 @@ class PortStateWrite(FeedbackCommand):
                                           WriteMask = [ 0xff, 0xff, 0xff] ) )
     [ None ]
     """
-    def __init__(self, State, WriteMask = [ 0xff, 0xff, 0xff]):
+    def __init__(self, State, WriteMask=[0xff, 0xff, 0xff]):
         self.state = State
         self.writeMask = WriteMask
-        self.cmdBytes = [ 27 ] + WriteMask + State
+        self.cmdBytes = [27] + WriteMask + State
 
     def __repr__(self):
         return "<u6.PortStateWrite( State = %s, WriteMask = %s )>" % (self.state, self.writeMask)
@@ -1995,7 +1995,7 @@ class PortDirRead(FeedbackCommand):
     [ { 'FIO' : 10, 'EIO' : 0, 'CIO' : 0 } ]
     """
     def __init__(self):
-        self.cmdBytes = [ 28 ]
+        self.cmdBytes = [28]
 
     def __repr__(self):
         return "<u6.PortDirRead()>"
@@ -2003,7 +2003,7 @@ class PortDirRead(FeedbackCommand):
     readLen = 3
 
     def handle(self, input):
-        return {'FIO' : input[0], 'EIO' : input[1], 'CIO' : input[2] }
+        return {'FIO': input[0], 'EIO': input[1], 'CIO': input[2]}
 
 class PortDirWrite(FeedbackCommand):
     """
@@ -2016,10 +2016,10 @@ class PortDirWrite(FeedbackCommand):
                                         WriteMask = [ 0xff, 0xff, 0xff] ) )
     [ None ]
     """
-    def __init__(self, Direction, WriteMask = [ 0xff, 0xff, 0xff]):
+    def __init__(self, Direction, WriteMask=[0xff, 0xff, 0xff]):
         self.direction = Direction
         self.writeMask = WriteMask
-        self.cmdBytes = [ 29 ] + WriteMask + Direction
+        self.cmdBytes = [29] + WriteMask + Direction
 
     def __repr__(self):
         return "<u6.PortDirWrite( Direction = %s, WriteMask = %s )>" % (self.direction, self.writeMask)
@@ -2039,7 +2039,7 @@ class DAC8(FeedbackCommand):
     def __init__(self, Dac, Value):
         self.dac = Dac
         self.value = Value % 256
-        self.cmdBytes = [ 34 + (Dac % 2), Value % 256 ]
+        self.cmdBytes = [34 + (Dac % 2), Value % 256]
 
     def __repr__(self):
         return "<u6.DAC8( Dac = %s, Value = %s )>" % (self.dac, self.value)
@@ -2093,7 +2093,7 @@ class DAC16(FeedbackCommand):
     def __init__(self, Dac, Value):
         self.dac = Dac
         self.value = Value
-        self.cmdBytes = [ 38 + (Dac % 2), Value % 256, Value >> 8 ]
+        self.cmdBytes = [38 + (Dac % 2), Value % 256, Value >> 8]
 
     def __repr__(self):
         return "<u6.DAC8( Dac = %s, Value = %s )>" % (self.dac, self.value)
@@ -2157,7 +2157,7 @@ class Timer(FeedbackCommand):
     ... , Mode = None ) )
     [ 12314 ]
     """
-    def __init__(self, timer, UpdateReset = False, Value=0, Mode = None):
+    def __init__(self, timer, UpdateReset=False, Value=0, Mode=None):
         if timer not in range(4):
             raise LabJackException("Timer should be 0-3.")
         if UpdateReset and (Value is None):
@@ -2168,7 +2168,7 @@ class Timer(FeedbackCommand):
         self.value = Value
         self.mode = Mode
 
-        self.cmdBytes = [ (42 + (2*timer)), UpdateReset, Value % 256, Value >> 8 ]
+        self.cmdBytes = [(42 + (2 * timer)), UpdateReset, Value % 256, Value >> 8]
 
     readLen = 4
 
@@ -2178,12 +2178,12 @@ class Timer(FeedbackCommand):
     def handle(self, input):
         inStr = pack('B' * len(input), *input)
         if self.mode == 8:
-            return unpack('<i', inStr )[0]
+            return unpack('<i', inStr)[0]
         elif self.mode == 9:
-            maxCount, current = unpack('<HH', inStr )
+            maxCount, current = unpack('<HH', inStr)
             return current, maxCount
         else:
-            return unpack('<I', inStr )[0]
+            return unpack('<I', inStr)[0]
 
 
 class Timer0(Timer):
@@ -2204,7 +2204,7 @@ class Timer0(Timer):
     ... Mode = None ) )
     [ 12314 ]
     """
-    def __init__(self, UpdateReset = False, Value = 0, Mode = None):
+    def __init__(self, UpdateReset=False, Value=0, Mode=None):
         Timer.__init__(self, 0, UpdateReset, Value, Mode)
 
     def __repr__(self):
@@ -2229,7 +2229,7 @@ class Timer1(Timer):
     ... Mode = None ) )
     [ 12314 ]
     """
-    def __init__(self, UpdateReset = False, Value = 0, Mode = None):
+    def __init__(self, UpdateReset=False, Value=0, Mode=None):
         Timer.__init__(self, 1, UpdateReset, Value, Mode)
 
     def __repr__(self):
@@ -2254,7 +2254,7 @@ class Timer2(Timer):
     ... Mode = None ) )
     [ 12314 ]
     """
-    def __init__(self, UpdateReset = False, Value = 0, Mode = None):
+    def __init__(self, UpdateReset=False, Value=0, Mode=None):
         Timer.__init__(self, 2, UpdateReset, Value, Mode)
 
     def __repr__(self):
@@ -2279,7 +2279,7 @@ class Timer3(Timer):
     ... Mode = None ) )
     [ 12314 ]
     """
-    def __init__(self, UpdateReset = False, Value = 0, Mode = None):
+    def __init__(self, UpdateReset=False, Value=0, Mode=None):
         Timer.__init__(self, 3, UpdateReset, Value, Mode)
 
     def __repr__(self):
@@ -2306,8 +2306,8 @@ class QuadratureInputTimer(Timer):
     >>> d.getFeedback( u6.QuadratureInputTimer() )
     [-21]
     """
-    def __init__(self, UpdateReset = False, Value = 0):
-        Timer.__init__(self, 0, UpdateReset, Value, Mode = 8)
+    def __init__(self, UpdateReset=False, Value=0):
+        Timer.__init__(self, 0, UpdateReset, Value, Mode=8)
 
     def __repr__(self):
         return "<u6.QuadratureInputTimer( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)
@@ -2334,8 +2334,8 @@ class TimerStopInput1(Timer1):
     >>> d.getFeedback( u6.TimerStopInput1() )
     [(0, 30)]
     """
-    def __init__(self, UpdateReset = False, Value = 0):
-        Timer1.__init__(self, UpdateReset, Value, Mode = 9)
+    def __init__(self, UpdateReset=False, Value=0):
+        Timer1.__init__(self, UpdateReset, Value, Mode=9)
 
     def __repr__(self):
         return "<u6.TimerStopInput1( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)
@@ -2383,7 +2383,7 @@ class Timer0Config(TimerConfig):
     >>> d.getFeedback( u6.Timer0Config( TimerMode, Value = 0 ) )
     [ None ]
     """
-    def __init__(self, TimerMode, Value = 0):
+    def __init__(self, TimerMode, Value=0):
         TimerConfig.__init__(self, 0, TimerMode, Value)
 
     def __repr__(self):
@@ -2401,7 +2401,7 @@ class Timer1Config(TimerConfig):
     >>> d.getFeedback( u6.Timer1Config( TimerMode, Value = 0 ) )
     [ None ]
     """
-    def __init__(self, TimerMode, Value = 0):
+    def __init__(self, TimerMode, Value=0):
         TimerConfig.__init__(self, 1, TimerMode, Value)
 
     def __repr__(self):
@@ -2419,7 +2419,7 @@ class Timer2Config(TimerConfig):
     >>> d.getFeedback( u6.Timer2Config( TimerMode, Value = 0 ) )
     [ None ]
     """
-    def __init__(self, TimerMode, Value = 0):
+    def __init__(self, TimerMode, Value=0):
         TimerConfig.__init__(self, 2, TimerMode, Value)
 
     def __repr__(self):
@@ -2437,7 +2437,7 @@ class Timer3Config(TimerConfig):
     >>> d.getFeedback( u6.Timer3Config( TimerMode, Value = 0 ) )
     [ None ]
     """
-    def __init__(self, TimerMode, Value = 0):
+    def __init__(self, TimerMode, Value=0):
         TimerConfig.__init__(self, 3, TimerMode, Value)
 
     def __repr__(self):
@@ -2488,7 +2488,7 @@ class Counter0(Counter):
     >>> d.getFeedback(u6.Counter0(Reset = False))
     [ 2183 ]
     '''
-    def __init__(self, Reset = False):
+    def __init__(self, Reset=False):
         Counter.__init__(self, 0, Reset)
 
     def __repr__(self):
@@ -2509,7 +2509,7 @@ class Counter1(Counter):
     >>> d.getFeedback(u6.Counter1(Reset = False))
     [ 2183 ]
     '''
-    def __init__(self, Reset = False):
+    def __init__(self, Reset=False):
         Counter.__init__(self, 1, Reset)
 
     def __repr__(self):

--- a/src/u6.py
+++ b/src/u6.py
@@ -2335,7 +2335,7 @@ class TimerStopInput1(Timer1):
     [(0, 30)]
     """
     def __init__(self, UpdateReset = False, Value = 0):
-        Timer.__init__(self, 1, UpdateReset, Value, Mode = 9)
+        Timer1.__init__(self, UpdateReset, Value, Mode = 9)
 
     def __repr__(self):
         return "<u6.TimerStopInput1( UpdateReset = %s, Value = %s )>" % (self.updateReset, self.value)

--- a/src/u6.py
+++ b/src/u6.py
@@ -21,16 +21,11 @@ except ImportError:  # Python 3
 
 from struct import pack, unpack
 
-from LabJackPython import (
-    Device,
-    deviceCount,
-    LabJackException,
-    LowlevelErrorException,
-    lowlevelErrorToString,
-    MAX_USB_PACKET_LENGTH,
-    setChecksum8,
-    toDouble,
-    )
+from LabJackPython import (Device, deviceCount, LabJackException,
+                           LowlevelErrorException,
+                           lowlevelErrorToString,
+                           MAX_USB_PACKET_LENGTH, setChecksum8,
+                           toDouble)
 
 
 def openAllU6():
@@ -1658,6 +1653,7 @@ class FeedbackCommand(object):
     and call getFeedback.
     '''
     readLen = 0
+
     def handle(self, input):
         return None
 

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -17,7 +17,7 @@ import warnings
 
 try:
     import ConfigParser
-except ImportError: # Python 3
+except ImportError:  # Python 3
     import configparser as ConfigParser
 
 from struct import pack, unpack
@@ -47,13 +47,13 @@ def openAllUE9():
     returnDict = dict()
 
     for i in range(deviceCount(9)):
-        d = UE9(firstFound = False, devNumber = i+1)
+        d = UE9(firstFound=False, devNumber=i + 1)
         returnDict[str(d.serialNumber)] = d
 
     return returnDict
 
 def parseIpAddress(bytes):
-    return "%s.%s.%s.%s" % (bytes[3], bytes[2], bytes[1], bytes[0] )
+    return "%s.%s.%s.%s" % (bytes[3], bytes[2], bytes[1], bytes[0])
 
 def unpackInt(bytes):
     return unpack("<I", pack("BBBB", *bytes))[0]
@@ -61,7 +61,7 @@ def unpackInt(bytes):
 def unpackShort(bytes):
     return unpack("<H", pack("BB", *bytes))[0]
 
-DEFAULT_CAL_CONSTANTS = { "AINSlopes" : { '0' : 0.000077503, '1' : 0.000038736, '2' : 0.000019353, '3' : 0.0000096764, '8' : 0.00015629  }, "AINOffsets" : { '0' : -0.012000, '1' : -0.012000, '2' : -0.012000, '3' : -0.012000, '8' : -5.1760 }, "TempSlope" : 0.012968, "DACSlopes" : { '0' : 842.59, '1' : 842.59}, "DACOffsets" : { '0' : 0.0, '1': 0.0} }
+DEFAULT_CAL_CONSTANTS = {"AINSlopes": {'0': 0.000077503, '1': 0.000038736, '2': 0.000019353, '3': 0.0000096764, '8': 0.00015629}, "AINOffsets": {'0': -0.012000, '1': -0.012000, '2': -0.012000, '3': -0.012000, '8': -5.1760}, "TempSlope": 0.012968, "DACSlopes": {'0': 842.59, '1': 842.59}, "DACOffsets": {'0': 0.0, '1': 0.0}}
 
 class UE9(Device):
     """
@@ -73,7 +73,7 @@ class UE9(Device):
     >>> print(d.commConfig())
     {'CommFWVersion': '1.47', ..., 'IPAddress': '192.168.1.114'}
     """
-    def __init__(self, debug = False, autoOpen = True, **kargs):
+    def __init__(self, debug=False, autoOpen=True, **kargs):
         """
         Name: UE9.__init__(self)
         Args: debug, True for debug information
@@ -81,7 +81,7 @@ class UE9(Device):
 
         >>> myUe9 = ue9.UE9()
         """
-        Device.__init__(self, None, devType = 9)
+        Device.__init__(self, None, devType=9)
 
         self.debug = debug
         self.calData = None
@@ -91,7 +91,7 @@ class UE9(Device):
         if autoOpen:
             self.open(**kargs)
 
-    def open(self, firstFound = True, serial = None, ipAddress = None, localId = None, devNumber = None, ethernet=False, handleOnly = False, LJSocket = None):
+    def open(self, firstFound=True, serial=None, ipAddress=None, localId=None, devNumber=None, ethernet=False, handleOnly=False, LJSocket=None):
         """
         Name: UE9.open(firstFound = True, ipAddress = None, localId = None, devNumber = None, ethernet=False)
         Args: firstFound, Open the first found UE9
@@ -108,9 +108,9 @@ class UE9(Device):
         >>> myUe9.open()
         """
         self.ethernet = ethernet
-        Device.open(self, 9, Ethernet = ethernet, firstFound = firstFound, serial = serial, localId = localId, devNumber = devNumber, ipAddress = ipAddress, handleOnly = handleOnly, LJSocket = LJSocket)
+        Device.open(self, 9, Ethernet=ethernet, firstFound=firstFound, serial=serial, localId=localId, devNumber=devNumber, ipAddress=ipAddress, handleOnly=handleOnly, LJSocket=LJSocket)
 
-    def commConfig(self, LocalID = None, IPAddress = None, Gateway = None, Subnet = None, PortA = None, PortB = None, DHCPEnabled = None):
+    def commConfig(self, LocalID=None, IPAddress=None, Gateway=None, Subnet=None, PortA=None, PortB=None, DHCPEnabled=None):
         """
         Name: UE9.commConfig(LocalID = None, IPAddress = None, Gateway = None,
                 Subnet = None, PortA = None, PortB = None, DHCPEnabled = None)
@@ -140,16 +140,16 @@ class UE9(Device):
          'SerialNumber': 27121XXXX,
          'Subnet': '255.255.255.0'}
         """
-        command = [ 0 ] * 38
+        command = [0] * 38
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0x78
         command[2] = 0x10
         command[3] = 0x01
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #command[6] = Writemask. Set it along the way.
-        #command[7] = Reserved
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # command[6] = Writemask. Set it along the way.
+        # command[7] = Reserved
         if LocalID is not None:
             command[6] |= 1
             command[8] = LocalID
@@ -157,21 +157,21 @@ class UE9(Device):
         if IPAddress is not None:
             command[6] |= (1 << 2)
             ipbytes = IPAddress.split('.')
-            ipbytes = [ int(x) for x in ipbytes ]
+            ipbytes = [int(x) for x in ipbytes]
             ipbytes.reverse()
             command[10:14] = ipbytes
 
         if Gateway is not None:
             command[6] |= (1 << 3)
             gwbytes = Gateway.split('.')
-            gwbytes = [ int(x) for x in gwbytes ]
+            gwbytes = [int(x) for x in gwbytes]
             gwbytes.reverse()
             command[14:18] = gwbytes
 
         if Subnet is not None:
             command[6] |= (1 << 4)
             snbytes = Subnet.split('.')
-            snbytes = [ int(x) for x in snbytes ]
+            snbytes = [int(x) for x in snbytes]
             snbytes.reverse()
             command[18:21] = snbytes
 
@@ -192,13 +192,13 @@ class UE9(Device):
             if DHCPEnabled:
                 command[26] = 1
 
-        result = self._writeRead(command, 38, [], checkBytes = False)
+        result = self._writeRead(command, 38, [], checkBytes=False)
 
         if len(result) == 0:
             raise LabJackException("Got a zero length packet.")
         elif result[0] == 0xB8 and result[1] == 0xB8:
             raise LabJackException("Device detected a bad checksum.")
-        elif result[1:4] != [ 0x78, 0x10, 0x01 ]:
+        elif result[1:4] != [0x78, 0x10, 0x01]:
             raise LabJackException("Got incorrect command bytes.")
         elif not verifyChecksum(result):
             raise LabJackException("Checksum was incorrect.")
@@ -221,7 +221,7 @@ class UE9(Device):
         self.commFWVersion = "%s.%02d" % (result[37], result[36])
         self.firmwareVersion = [self.controlFWVersion, self.commFWVersion]
 
-        return { 'LocalID' : self.localId, 'PowerLevel' : self.powerLevel, 'IPAddress' : self.ipAddress, 'Gateway' : self.gateway, 'Subnet' : self.subnet, 'PortA' : self.portA, 'PortB' : self.portB, 'DHCPEnabled' : self.DHCPEnabled, 'ProductID' : self.productId, 'MACAddress' : self.macAddress, 'HWVersion' : self.hwVersion, 'CommFWVersion' : self.commFWVersion, 'SerialNumber' : self.serialNumber}
+        return {'LocalID': self.localId, 'PowerLevel': self.powerLevel, 'IPAddress': self.ipAddress, 'Gateway': self.gateway, 'Subnet': self.subnet, 'PortA': self.portA, 'PortB': self.portB, 'DHCPEnabled': self.DHCPEnabled, 'ProductID': self.productId, 'MACAddress': self.macAddress, 'HWVersion': self.hwVersion, 'CommFWVersion': self.commFWVersion, 'SerialNumber': self.serialNumber}
 
     def flushBuffer(self):
         """
@@ -251,7 +251,7 @@ class UE9(Device):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         host = '255.255.255.255'
         port = 52362
-        addr = (host,port)
+        addr = (host, port)
 
         sndBuffer = [0] * 6
         sndBuffer[0] = 0x22
@@ -274,24 +274,24 @@ class UE9(Device):
 
         listen = True
         while listen:
-            #We will wait 2 seconds for a response from a Ue9
+            # We will wait 2 seconds for a response from a Ue9
             rs, _, _ = select.select(inputs, [], [], 1)
             listen = False
             for r in rs:
                 if r is s:
-                    data,addr = s.recvfrom(38)
+                    data, addr = s.recvfrom(38)
                     ue9s[addr[0]] = data
                     listen = True
         s.close()
 
         for ip, data in ue9s.items():
-            data = list(unpack("B"*38, data))
-            ue9 = { 'LocalID' : data[8], 'PowerLevel' : data[9] , 'IPAddress' : parseIpAddress(data[10:14]), 'Gateway' : parseIpAddress(data[14:18]), 'Subnet' : parseIpAddress(data[18:23]), 'PortA' : unpack("<H", pack("BB", *data[22:24]))[0], 'PortB' : unpack("<H", pack("BB", *data[24:26]))[0], 'DHCPEnabled' : bool(data[26]), 'ProductID' : data[27], 'MACAddress' : "%02X:%02X:%02X:%02X:%02X:%02X" % (data[33], data[32], data[31], data[30], data[29], data[28]), 'SerialNumber' : unpack("<I", pack("BBBB", data[28], data[29], data[30], 0x10))[0], 'HWVersion' : "%s.%02d" % (data[35], data[34]), 'CommFWVersion' : "%s.%02d" % (data[37], data[36])}
+            data = list(unpack("B" * 38, data))
+            ue9 = {'LocalID': data[8], 'PowerLevel': data[9], 'IPAddress': parseIpAddress(data[10:14]), 'Gateway': parseIpAddress(data[14:18]), 'Subnet': parseIpAddress(data[18:23]), 'PortA': unpack("<H", pack("BB", *data[22:24]))[0], 'PortB': unpack("<H", pack("BB", *data[24:26]))[0], 'DHCPEnabled': bool(data[26]), 'ProductID': data[27], 'MACAddress': "%02X:%02X:%02X:%02X:%02X:%02X" % (data[33], data[32], data[31], data[30], data[29], data[28]), 'SerialNumber': unpack("<I", pack("BBBB", data[28], data[29], data[30], 0x10))[0], 'HWVersion': "%s.%02d" % (data[35], data[34]), 'CommFWVersion': "%s.%02d" % (data[37], data[36])}
             ue9s[ip] = ue9
 
         return ue9s
 
-    def ipAddressFilter(self, Write = 0, IP0 = None, IP1 = None, IP2 = None, IP3 = None, IP4 = None):
+    def ipAddressFilter(self, Write=0, IP0=None, IP1=None, IP2=None, IP3=None, IP4=None):
         """
         Name: UE9.ipAddressFilter(Write = 0, IP0 = None, IP1 = None, IP2 = None, IP3 = None, IP4 = None)
         Args: Write, Set to non-zero if new values should be updated or
@@ -314,7 +314,7 @@ class UE9(Device):
               User's Guide.
               Requires Comm. firmware 1.56 or newer.
         """
-        command = [ 0 ] * 28
+        command = [0] * 28
         command[1] = 0x78
         command[2] = 0x0B
         command[3] = 0xAF
@@ -327,29 +327,29 @@ class UE9(Device):
         for ip in ips:
             if ip is not None:
                 ipbytes = ip.split('.')
-                ipbytes = [ int(x) for x in ipbytes ]
+                ipbytes = [int(x) for x in ipbytes]
                 ipbytes.reverse()
             else:
                 ipbytes = [255, 255, 255, 255]
-            command[startbyte:(startbyte+4)] = ipbytes
+            command[startbyte:(startbyte + 4)] = ipbytes
             startbyte += 4
 
-        result = self._writeRead(command, 28, [], checkBytes = False)
+        result = self._writeRead(command, 28, [], checkBytes=False)
 
         if len(result) == 0:
             raise LabJackException("Got a zero length packet.")
         elif result[0] == 0xB8 and result[1] == 0xB8:
             raise LabJackException("Device detected a bad checksum.")
-        elif result[1:4] != [ 0x78, 0x0B, 0xAF ]:
+        elif result[1:4] != [0x78, 0x0B, 0xAF]:
             raise LabJackException("Got incorrect command bytes.")
         elif not verifyChecksum(result):
             raise LabJackException("Checksum was incorrect.")
         elif result[7] != 0:
-            raise LowlevelErrorException(result[7], "\nThe %s returned an error:\n    %s" % (self.deviceName, lowlevelErrorToString(result[7])) )
+            raise LowlevelErrorException(result[7], "\nThe %s returned an error:\n    %s" % (self.deviceName, lowlevelErrorToString(result[7])))
 
-        return { 'IP0' : parseIpAddress(result[8:12]), 'IP1' : parseIpAddress(result[12:16]), 'IP2' : parseIpAddress(result[16:20]), 'IP3' : parseIpAddress(result[20:24]), 'IP4' : parseIpAddress(result[24:28]) }
+        return {'IP0': parseIpAddress(result[8:12]), 'IP1': parseIpAddress(result[12:16]), 'IP2': parseIpAddress(result[16:20]), 'IP3': parseIpAddress(result[20:24]), 'IP4': parseIpAddress(result[24:28])}
 
-    def controlConfig(self, PowerLevel = None, FIODir = None, FIOState = None, EIODir = None, EIOState = None, CIODirection = None, CIOState = None, MIODirection = None, MIOState = None, DoNotLoadDigitalIODefaults = None, DAC0Enable = None, DAC0 = None, DAC1Enable = None, DAC1 = None):
+    def controlConfig(self, PowerLevel=None, FIODir=None, FIOState=None, EIODir=None, EIOState=None, CIODirection=None, CIOState=None, MIODirection=None, MIOState=None, DoNotLoadDigitalIODefaults=None, DAC0Enable=None, DAC0=None, DAC1Enable=None, DAC1=None):
         """
         Name: UE9.controlConfig(PowerLevel = None, FIODir = None,
               FIOState = None, EIODir = None,
@@ -395,15 +395,15 @@ class UE9(Device):
          'PowerLevel': 0,
          'ResetSource': 119}
         """
-        command = [ 0 ] * 18
+        command = [0] * 18
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x06
         command[3] = 0x08
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #command[6] = Writemask. Set it along the way.
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # command[6] = Writemask. Set it along the way.
 
         if PowerLevel is not None:
             command[6] |= 1
@@ -431,7 +431,7 @@ class UE9(Device):
 
         if CIOState is not None:
             command[6] |= (1 << 1)
-            command[12] |= ( CIOState & 0xf )
+            command[12] |= (CIOState & 0xf)
 
         if DoNotLoadDigitalIODefaults is not None:
             command[6] |= (1 << 1)
@@ -479,7 +479,7 @@ class UE9(Device):
 
         return {'PowerLevel': self.powerLevel, 'ResetSource': result[8], 'ControlFWVersion': self.controlFWVersion, 'ControlBLVersion': self.controlBLVersion, 'HiRes Flag': self.hiRes, 'FIODir': result[14], 'FIOState': result[15], 'EIODir': result[16], 'EIOState': result[17], 'CIODirection': (result[18] >> 4) & 0xf, 'CIOState': result[18] & 0xf, 'MIODirection': (result[19] >> 4) & 7, 'MIOState': result[19] & 7, 'DAC0 Enabled': bool(result[21] >> 7 & 1), 'DAC0': (result[21] & 0xf) + result[20], 'DAC1 Enabled': bool(result[23] >> 7 & 1), 'DAC1': (result[23] & 0xf) + result[22], 'DeviceName': self.deviceName}
 
-    def feedback(self, FIOMask = 0, FIODir = 0, FIOState = 0, EIOMask = 0, EIODir = 0, EIOState = 0, CIOMask = 0, CIODirection = 0, CIOState = 0, MIOMask = 0, MIODirection = 0, MIOState = 0, DAC0Update = False, DAC0Enabled = False, DAC0 = 0, DAC1Update = False, DAC1Enabled = False, DAC1 = 0, AINMask = 0, AIN14ChannelNumber = 0, AIN15ChannelNumber = 0, Resolution = 0, SettlingTime = 0, AIN1_0_BipGain = 0, AIN3_2_BipGain = 0, AIN5_4_BipGain  = 0, AIN7_6_BipGain = 0, AIN9_8_BipGain = 0, AIN11_10_BipGain = 0, AIN13_12_BipGain = 0, AIN15_14_BipGain = 0):
+    def feedback(self, FIOMask=0, FIODir=0, FIOState=0, EIOMask=0, EIODir=0, EIOState=0, CIOMask=0, CIODirection=0, CIOState=0, MIOMask=0, MIODirection=0, MIOState=0, DAC0Update=False, DAC0Enabled=False, DAC0=0, DAC1Update=False, DAC1Enabled=False, DAC1=0, AINMask=0, AIN14ChannelNumber=0, AIN15ChannelNumber=0, Resolution=0, SettlingTime=0, AIN1_0_BipGain=0, AIN3_2_BipGain=0, AIN5_4_BipGain=0, AIN7_6_BipGain=0, AIN9_8_BipGain=0, AIN11_10_BipGain=0, AIN13_12_BipGain=0, AIN15_14_BipGain=0):
         """
         Name: UE9.feedback(FIOMask = 0, FIODir = 0, FIOState = 0,
               EIOMask = 0, EIODir = 0, EIOState = 0, CIOMask = 0,
@@ -501,14 +501,14 @@ class UE9(Device):
          'TimerB': 0,
          'TimerC': 0}
         """
-        command = [ 0 ] * 34
+        command = [0] * 34
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x0E
         command[3] = 0x00
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = FIOMask
         command[7] = FIODir
         command[8] = FIOState
@@ -520,7 +520,7 @@ class UE9(Device):
         command[13] |= (CIOState & 0xf)
         command[14] = MIOMask
         command[15] = (MIODirection & 7) << 4
-        command[15] |= (MIOState & 7 )
+        command[15] |= (MIOState & 7)
 
         if DAC0Update:
             if DAC0Enabled:
@@ -553,19 +553,19 @@ class UE9(Device):
         command[32] = AIN13_12_BipGain
         command[33] = AIN15_14_BipGain
 
-        result = self._writeRead(command, 64, [ 0xF8, 0x1D, 0x00], checkBytes = False)
+        result = self._writeRead(command, 64, [0xF8, 0x1D, 0x00], checkBytes=False)
 
-        returnDict = { 'FIODir' : result[6], 'FIOState' : result[7], 'EIODir' : result[8], 'EIOState' : result[9], 'CIODir' : (result[10] >> 4) & 0xf, 'CIOState' : result[10] & 0xf, 'MIODir' : (result[11] >> 4) & 7, 'MIOState' : result[11] & 7, 'Counter0' : unpackInt(result[44:48]), 'Counter1' : unpackInt(result[48:52]), 'TimerA' : unpackInt(result[52:56]), 'TimerB' : unpackInt(result[56:60]), 'TimerC' : unpackInt(result[60:]) }
+        returnDict = {'FIODir': result[6], 'FIOState': result[7], 'EIODir': result[8], 'EIOState': result[9], 'CIODir': (result[10] >> 4) & 0xf, 'CIOState': result[10] & 0xf, 'MIODir': (result[11] >> 4) & 7, 'MIOState': result[11] & 7, 'Counter0': unpackInt(result[44:48]), 'Counter1': unpackInt(result[48:52]), 'TimerA': unpackInt(result[52:56]), 'TimerB': unpackInt(result[56:60]), 'TimerC': unpackInt(result[60:])}
 
         """
-'AIN0' : b2c(unpackShort(result[12:14])), 'AIN1' : unpackShort(result[14:16]), 'AIN2' : unpackShort(result[16:18]), 'AIN3' : unpackShort(result[18:20]), 'AIN4' : unpackShort(result[20:22]), 'AIN5' : unpackShort(result[22:24]), 'AIN6' : unpackShort(result[24:26]), 'AIN7' : unpackShort(result[26:28]), 'AIN8' : unpackShort(result[28:30]), 'AIN9' : unpackShort(result[30:32]), 'AIN10' : unpackShort(result[32:34]), 'AIN11' : unpackShort(result[34:36]), 'AIN12' : unpackShort(result[36:38]), 'AIN13' : unpackShort(result[38:40]), 'AIN14' : unpackShort(result[40:42]), 'AIN15' : unpackShort(result[42:44]),
+'AIN0' : b2c(unpackShort(result[12:14])), 'AIN1' : unpackShort(result[14:16]), 'AIN2' : unpackShort(result[16:18]), 'AIN3' : unpackShort(result[18:20]), 'AIN4': unpackShort(result[20:22]), 'AIN5': unpackShort(result[22:24]), 'AIN6': unpackShort(result[24:26]), 'AIN7': unpackShort(result[26:28]), 'AIN8': unpackShort(result[28:30]), 'AIN9': unpackShort(result[30:32]), 'AIN10': unpackShort(result[32:34]), 'AIN11': unpackShort(result[34:36]), 'AIN12': unpackShort(result[36:38]), 'AIN13': unpackShort(result[38:40]), 'AIN14': unpackShort(result[40:42]), 'AIN15': unpackShort(result[42:44]),
         """
 
         b2c = self.binaryToCalibratedAnalogVoltage
         g = 0
         for i in range(16):
-            bits = unpackShort(result[(12+(2*i)):(14+(2*i))])
-            if i%2 == 0:
+            bits = unpackShort(result[(12 + (2 * i)):(14 + (2 * i))])
+            if i % 2 == 0:
                 gain = command[26 + g] & 0xf
             else:
                 gain = (command[26 + g] >> 4) & 0xf
@@ -574,8 +574,8 @@ class UE9(Device):
 
         return returnDict
 
-    digitalPorts = [ 'FIO', 'EIO', 'CIO', 'MIO' ]
-    def singleIO(self, IOType, Channel, Dir = None, BipGain = None, State = None, Resolution = None, DAC = 0, SettlingTime = 0):
+    digitalPorts = ['FIO', 'EIO', 'CIO', 'MIO']
+    def singleIO(self, IOType, Channel, Dir=None, BipGain=None, State=None, Resolution=None, DAC=0, SettlingTime=0):
         """
         Name: UE9.singleIO(IOType, Channel, Dir = None, BipGain = None, State = None, Resolution = None, DAC = 0, SettlingTime = 0)
         Args: See section 5.3.4 of the User's Guide
@@ -587,67 +587,67 @@ class UE9(Device):
         >>> myUe9.singleIO(1, 0, Dir = 1, State = 0)
         {'FIO0 Direction': 1, 'FIO0 State': 0}
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xA3
         command[2] = IOType
         command[3] = Channel
 
         if IOType == 0:
-            #Digital Bit Read
+            # Digital Bit Read
             pass
         elif IOType == 1:
-            #Digital Bit Write
+            # Digital Bit Write
             if (Dir is None) or (State is None):
                 raise LabJackException("Need to specify a direction and state")
             command[4] = Dir
             command[5] = State
         elif IOType == 2:
-            #Digital Port Read
+            # Digital Port Read
             pass
         elif IOType == 3:
-            #Digital Port Write
+            # Digital Port Write
             if (Dir is None) or (State is None):
                 raise LabJackException("Need to specify a direction and state")
             command[4] = Dir
             command[5] = State
         elif IOType == 4:
-            #Analog In
+            # Analog In
             if (BipGain is None) or (Resolution is None) or (SettlingTime is None):
                 raise LabJackException("Need to specify a BipGain, Resolution, and SettlingTime")
             command[4] = BipGain
             command[5] = Resolution
             command[6] = SettlingTime
         elif IOType == 5:
-            #Analog Out
+            # Analog Out
             if DAC is None:
                 raise LabJackException("Need to specify a DAC Value")
             command[4] = DAC & 0xff
             command[5] = (DAC >> 8) & 0xf
 
-        result = self._writeRead(command, 8, [ 0xA3 ], checkBytes = False)
+        result = self._writeRead(command, 8, [0xA3], checkBytes=False)
 
         if result[2] == 0:
-            #Digital Bit Read
-            return { "FIO%s State" % result[3] : result[5], "FIO%s Direction" % result[3] : result[4] }
+            # Digital Bit Read
+            return {"FIO%s State" % result[3]: result[5], "FIO%s Direction" % result[3]: result[4]}
         elif result[2] == 1:
-            #Digital Bit Write
-            return { "FIO%s State" % result[3] : result[5], "FIO%s Direction" % result[3] : result[4] }
+            # Digital Bit Write
+            return {"FIO%s State" % result[3]: result[5], "FIO%s Direction" % result[3]: result[4]}
         elif result[2] == 2:
-            #Digital Port Read
-            return { "%s Direction" % self.digitalPorts[result[3]] : result[4], "%s State" % self.digitalPorts[result[3]] : result [5] }
+            # Digital Port Read
+            return {"%s Direction" % self.digitalPorts[result[3]]: result[4], "%s State" % self.digitalPorts[result[3]]: result[5]}
         elif result[2] == 3:
-            #Digital Port Write
-            return { "%s Direction" % self.digitalPorts[result[3]] : result[4], "%s State" % self.digitalPorts[result[3]] : result [5] }
+            # Digital Port Write
+            return {"%s Direction" % self.digitalPorts[result[3]]: result[4], "%s State" % self.digitalPorts[result[3]]: result[5]}
         elif result[2] == 4:
-            #Analog In
+            # Analog In
             ain = float((result[6] << 16) + (result[5] << 8) + result[4]) / 256
-            return { "AIN%s" % result[3] : ain }
+            return {"AIN%s" % result[3]: ain}
         elif result[2] == 5:
-            #Analog Out
+            # Analog Out
             dac = (result[6] << 16) + (result[5] << 8) + result[4]
-            return { "DAC%s" % result[3] : dac }
+            return {"DAC%s" % result[3]: dac}
 
     def timerCounter(self, TimerClockDivisor=0, UpdateConfig=False, NumTimersEnabled=0, Counter0Enabled=False, Counter1Enabled=False, TimerClockBase=LJ_tcSYS, ResetTimer0=False, ResetTimer1=False, ResetTimer2=False, ResetTimer3=False, ResetTimer4=False, ResetTimer5=False, ResetCounter0=False, ResetCounter1=False, Timer0Mode=None, Timer0Value=None, Timer1Mode=None, Timer1Value=None, Timer2Mode=None, Timer2Value=None, Timer3Mode=None, Timer3Value=None, Timer4Mode=None, Timer4Value=None, Timer5Mode=None, Timer5Value=None):
         """
@@ -694,14 +694,14 @@ class UE9(Device):
         >>> dev.timerCounter()
         {'Counter0Enabled': False, 'Timer5Enabled': False, 'Timer0Enabled': False, 'Timer1': 0, 'Timer4': 0, 'Timer3Enabled': False, 'Timer4Enabled': False, 'Timer5': 0, 'Counter1Enabled': False, 'Timer3': 0, 'Timer2': 0, 'Timer1Enabled': False, 'Timer0': 0, 'Timer2Enabled': False}
         """
-        command = [ 0 ] * 30
+        command = [0] * 30
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x0C
         command[3] = 0x18
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = TimerClockDivisor
 
         # Create EnableMask
@@ -763,10 +763,10 @@ class UE9(Device):
                 command[26] = Timer5Value & 0xff
                 command[27] = (Timer5Value >> 8) & 0xff
             if NumTimersEnabled > 7: raise LabJackException("Only a maximum of 5 timers can be enabled")
-            command[28] = 0#command[28] = Counter0Mode
-            command[29] = 0#command[29] = Counter1Mode
+            command[28] = 0  # command[28] = Counter0Mode
+            command[29] = 0  # command[29] = Counter1Mode
 
-        result = self._writeRead(command, 40, [ 0xF8, 0x11, 0x18 ])
+        result = self._writeRead(command, 40, [0xF8, 0x11, 0x18])
 
         # Parse the results
         returnValue = {}
@@ -775,10 +775,10 @@ class UE9(Device):
         for i in range(2):
             returnValue["Counter" + str(i) + "Enabled"] = result[7] >> i + 6 & 1 == 1
         for i in range(6):
-            returnValue["Timer" + str(i)] = unpackInt(result[8+i*4:12+i*4])
+            returnValue["Timer" + str(i)] = unpackInt(result[8 + i * 4:12 + i * 4])
         for i in range(2):
             counterValue = [0]
-            counterValue.extend(result[32+i*4:35+i*4])
+            counterValue.extend(result[32 + i * 4:35 + i * 4])
             returnValue["Counter" + str(i)] = unpackInt(counterValue)
 
         return returnValue
@@ -797,18 +797,18 @@ class UE9(Device):
 
         NOTE: Do not call this function while streaming.
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
         command[3] = 0x2A
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = 0x00
         command[7] = BlockNum
 
-        result = self._writeRead(command, 136, [ 0xF8, 0x41, 0x2A ])
+        result = self._writeRead(command, 136, [0xF8, 0x41, 0x2A])
 
         return result[8:]
 
@@ -829,14 +829,14 @@ class UE9(Device):
         if not isinstance(Data, list):
             raise LabJackException("Data must be a list of bytes")
 
-        command = [ 0 ] * 136
+        command = [0] * 136
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x41
         command[3] = 0x28
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = 0x00
         command[7] = BlockNum
         command[8:] = Data
@@ -859,14 +859,14 @@ class UE9(Device):
         if not isinstance(EraseCal, bool):
             raise LabJackException("EraseCal must be a Boolean value (True or False).")
 
-        command = [ 0 ] * 8
+        command = [0] * 8
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
         command[3] = 0x29
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
 
         if EraseCal:
             command[6] = 0x4C
@@ -887,7 +887,7 @@ class UE9(Device):
         """
         try:
             for _ in range(10):
-                res = self.read(192, stream = True)
+                res = self.read(192, stream=True)
                 if len(res) == 192:
                     if all([streamByteToInt(b) == 0 for b in res]):
                         # Stream data cleared (Windows)
@@ -903,7 +903,7 @@ class UE9(Device):
             # Probably a timeout, but expected
             pass
 
-    def streamConfig(self, NumChannels = 1, Resolution = 12, SettlingTime = 0, InternalStreamClockFrequency = 0, DivideClockBy256 = False, EnableExternalScanTrigger = False, EnableScanPulseOutput = False, ScanInterval = 1, ChannelNumbers = [0], ChannelOptions = [0], SampleFrequency = None, ScanFrequency = None):
+    def streamConfig(self, NumChannels=1, Resolution=12, SettlingTime=0, InternalStreamClockFrequency=0, DivideClockBy256=False, EnableExternalScanTrigger=False, EnableScanPulseOutput=False, ScanInterval=1, ChannelNumbers=[0], ChannelOptions=[0], SampleFrequency=None, ScanFrequency=None):
         """
         Name: UE9.streamConfig(NumChannels = 1, Resolution = 12,
                                SettlingTime = 0, InternalStreamClockFrequency = 0,
@@ -976,16 +976,16 @@ class UE9(Device):
                 DivideClockBy256 = True
                 if ScanFrequency >= 2.87:
                     InternalStreamClockFrequency = 1
-                    ScanInterval = (48000000/256) // ScanFrequency
+                    ScanInterval = (48000000 / 256) // ScanFrequency
                 elif ScanFrequency >= 1.44:
                     InternalStreamClockFrequency = 3
-                    ScanInterval = (24000000/256) // ScanFrequency
+                    ScanInterval = (24000000 / 256) // ScanFrequency
                 elif ScanFrequency >= 0.239:
                     InternalStreamClockFrequency = 0
-                    ScanInterval = (4000000/256) // ScanFrequency
+                    ScanInterval = (4000000 / 256) // ScanFrequency
                 else:
                     InternalStreamClockFrequency = 2
-                    ScanInterval = (750000/256) // ScanFrequency
+                    ScanInterval = (750000 / 256) // ScanFrequency
 
         SamplesPerPacket = 16
 
@@ -997,9 +997,9 @@ class UE9(Device):
         # Only want the first 2 bit of data
         InternalStreamClockFrequency = InternalStreamClockFrequency & 3
 
-        command = [0] * (12 + NumChannels*2)
+        command = [0] * (12 + NumChannels * 2)
         command[1] = 0xF8
-        command[2] = NumChannels+3
+        command[2] = NumChannels + 3
         command[3] = 0x11
         command[6] = NumChannels
         command[7] = Resolution
@@ -1014,8 +1014,8 @@ class UE9(Device):
         command[10] = ScanInterval & 0xFF
         command[11] = (ScanInterval >> 8) & 0xFF
         for i in range(NumChannels):
-            command[12+(i*2)] = ChannelNumbers[i]
-            command[13+(i*2)] = ChannelOptions[i]
+            command[12 + (i * 2)] = ChannelNumbers[i]
+            command[13 + (i * 2)] = ChannelOptions[i]
 
         self._writeRead(command, 8, [0xF8, 0x01, 0x11])
 
@@ -1108,29 +1108,29 @@ class UE9(Device):
                 newTimeLoop = False
                 startTime = datetime.datetime.now()
 
-            result = self.read(numBytes * self.packetsPerRequest, stream = True)
+            result = self.read(numBytes * self.packetsPerRequest, stream=True)
             numPackets = len(result) // numBytes
             i = 0
             while i < numPackets:
-                offset = (i*numBytes)
+                offset = (i * numBytes)
                 # Check for empty data
-                if result[1+offset] == zeroVal:
-                    if all([b == zeroVal for b in result[offset:(offset+numBytes)]]):
-                        if i+1 >= numPackets:
+                if result[1 + offset] == zeroVal:
+                    if all([b == zeroVal for b in result[offset:(offset + numBytes)]]):
+                        if i + 1 >= numPackets:
                             result = result[0:offset]
                         else:
-                            result = result[0:offset] + result[offset+numBytes:]
+                            result = result[0:offset] + result[offset + numBytes:]
                         numPackets = numPackets - 1
                         continue
 
-                e = streamByteToInt(result[11+offset])
+                e = streamByteToInt(result[11 + offset])
                 if e != 0:
                     errors += 1
                     if self.debug:
                         print(e)
-                i+=1
+                i += 1
 
-            if len(result) == 0  and self.ethernet == False:
+            if len(result) == 0 and self.ethernet == False:
                 # No data over USB
                 yield None
                 continue
@@ -1150,7 +1150,7 @@ class UE9(Device):
                     resultBuffer = resultBuffer[(numBytes * self.packetsPerRequest):]
                 else:
                     curTime = datetime.datetime.now()
-                    timeElapsed = (curTime-startTime).seconds + float((curTime-startTime).microseconds)/1000000
+                    timeElapsed = (curTime - startTime).seconds + float((curTime - startTime).microseconds) / 1000000
                     if timeElapsed > 1.10:
                         newTimeLoop = True
                         if packetsInBuffer < 4:
@@ -1170,9 +1170,9 @@ class UE9(Device):
 
             firstPacket = streamByteToInt(result[10])
 
-            returnDict = dict(numPackets = numPackets, result = result, errors = errors, missed = missed, firstPacket = firstPacket)
+            returnDict = dict(numPackets=numPackets, result=result, errors=errors, missed=missed, firstPacket=firstPacket)
             if convert:
-                returnDict.update(self.processStreamData(result, numBytes = numBytes))
+                returnDict.update(self.processStreamData(result, numBytes=numBytes))
 
             errors = 0  # Reset error count
 
@@ -1210,7 +1210,7 @@ class UE9(Device):
         j = self.streamPacketOffset
         for packet in self.breakupPackets(result, numBytes):
             if self.ethernet == False:
-                packet = packet[:-2] #remove the extra bytes
+                packet = packet[:-2]  # remove the extra bytes
             for sample in self.samplesFromPacket(packet):
                 if j >= numChannels:
                     j = 0
@@ -1230,7 +1230,7 @@ class UE9(Device):
             self.streamPacketOffset = j
         return returnDict
 
-    def watchdogConfig(self, ResetCommonTimeout = False, ResetControlonTimeout = False, UpdateDigitalIOB = False, UpdateDigitalIOA = False, UpdateDAC1onTimeout = False, UpdateDAC0onTimeout = False, TimeoutPeriod = 60, DIOConfigA = 0, DIOConfigB = 0, DAC0Enabled = False, DAC0 = 0, DAC1Enabled = False, DAC1 = 0):
+    def watchdogConfig(self, ResetCommonTimeout=False, ResetControlonTimeout=False, UpdateDigitalIOB=False, UpdateDigitalIOA=False, UpdateDAC1onTimeout=False, UpdateDAC0onTimeout=False, TimeoutPeriod=60, DIOConfigA=0, DIOConfigB=0, DAC0Enabled=False, DAC0=0, DAC1Enabled=False, DAC1=0):
         """
         Name: UE9.watchdogConfig(ResetCommonTimeout = False, ResetControlonTimeout = False,
                                  UpdateDigitalIOB = False, UpdateDigitalIOA = False,
@@ -1242,7 +1242,7 @@ class UE9(Device):
         Args: See section 5.3.13.1 of the user's guide.
         Desc: Writes the configuration of the watchdog.
         """
-        command = [ 0 ] * 16
+        command = [0] * 16
 
         command[1] = 0xF8
         command[2] = 0x05
@@ -1281,7 +1281,7 @@ class UE9(Device):
 
         result = self._writeRead(command, 8, [0xF8, 0x01, 0x09])
 
-        return { 'UpdateDAC0onTimeout' : bool(result[7]& 1), 'UpdateDAC1onTimeout' : bool((result[7] >> 1) & 1), 'UpdateDigitalIOAonTimeout' : bool((result[7] >> 3) & 1), 'UpdateDigitalIOBonTimeout' : bool((result[7] >> 4) & 1), 'ResetControlOnTimeout' : bool((result[7] >> 5) & 1), 'ResetCommOnTimeout' : bool((result[7] >> 6) & 1) }
+        return {'UpdateDAC0onTimeout': bool(result[7] & 1), 'UpdateDAC1onTimeout': bool((result[7] >> 1) & 1), 'UpdateDigitalIOAonTimeout': bool((result[7] >> 3) & 1), 'UpdateDigitalIOBonTimeout': bool((result[7] >> 4) & 1), 'ResetControlOnTimeout': bool((result[7] >> 5) & 1), 'ResetCommOnTimeout': bool((result[7] >> 6) & 1)}
 
     def watchdogRead(self):
         """
@@ -1289,17 +1289,17 @@ class UE9(Device):
         Args: None
         Desc: Reads the current watchdog settings.
         """
-        command = [ 0 ] * 6
+        command = [0] * 6
         command[1] = 0xF8
         command[2] = 0x00
         command[3] = 0x09
 
         command = setChecksum8(command, 6)
 
-        result = self._writeRead(command, 16, [0xF8, 0x05, 0x09], checksum = False)
-        return { 'UpdateDAC0onTimeout' : bool(result[7]& 1), 'UpdateDAC1onTimeout' : bool((result[7] >> 1) & 1), 'UpdateDigitalIOAonTimeout' : bool((result[7] >> 3) & 1), 'UpdateDigitalIOBonTimeout' : bool((result[7] >> 4) & 1), 'ResetControlOnTimeout' : bool((result[7] >> 5) & 1), 'ResetCommOnTimeout' : bool((result[7] >> 6) & 1), 'TimeoutPeriod' : unpack('<H', pack("BB", *result[8:10]))[0], 'DIOConfigA' : result[10], 'DIOConfigB' : result[11], 'DAC0' : unpack('<H', pack("BB", *result[12:14]))[0], 'DAC1' : unpack('<H', pack("BB", *result[14:16]))[0] }
+        result = self._writeRead(command, 16, [0xF8, 0x05, 0x09], checksum=False)
+        return {'UpdateDAC0onTimeout': bool(result[7] & 1), 'UpdateDAC1onTimeout': bool((result[7] >> 1) & 1), 'UpdateDigitalIOAonTimeout': bool((result[7] >> 3) & 1), 'UpdateDigitalIOBonTimeout': bool((result[7] >> 4) & 1), 'ResetControlOnTimeout': bool((result[7] >> 5) & 1), 'ResetCommOnTimeout': bool((result[7] >> 6) & 1), 'TimeoutPeriod': unpack('<H', pack("BB", *result[8:10]))[0], 'DIOConfigA': result[10], 'DIOConfigB': result[11], 'DAC0': unpack('<H', pack("BB", *result[12:14]))[0], 'DAC1': unpack('<H', pack("BB", *result[14:16]))[0]}
 
-    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig = False, SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 1, CLKPinNum = 0, MISOPinNum = 3, MOSIPinNum = 2, CSPINNum = None):
+    def spi(self, SPIBytes, AutoCS=True, DisableDirConfig=False, SPIMode='A', SPIClockFactor=0, CSPinNum=1, CLKPinNum=0, MISOPinNum=3, MOSIPinNum=2, CSPINNum=None):
         """
         Name: UE9.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
                      SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 1,
@@ -1325,19 +1325,19 @@ class UE9(Device):
         numSPIBytes = len(SPIBytes)
 
         oddPacket = False
-        if numSPIBytes%2 != 0:
+        if numSPIBytes % 2 != 0:
             SPIBytes.append(0)
             numSPIBytes = numSPIBytes + 1
             oddPacket = True
 
-        command = [ 0 ] * (13 + numSPIBytes)
+        command = [0] * (13 + numSPIBytes)
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 4 + (numSPIBytes/2)
+        command[2] = 4 + (numSPIBytes / 2)
         command[3] = 0x3A
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
 
         if AutoCS:
             command[6] |= (1 << 7)
@@ -1346,12 +1346,12 @@ class UE9(Device):
 
         spiModes = ('A', 'B', 'C', 'D')
         try:
-            command[6] |= ( spiModes.index(SPIMode) & 3 )
+            command[6] |= (spiModes.index(SPIMode) & 3)
         except ValueError:
             raise LabJackException("Invalid SPIMode %r, valid modes are: %r" % (SPIMode, spiModes))
 
         command[7] = SPIClockFactor
-        #command[8] = Reserved
+        # command[8] = Reserved
         command[9] = CSPinNum
         command[10] = CLKPinNum
         command[11] = MISOPinNum
@@ -1362,14 +1362,14 @@ class UE9(Device):
 
         command[14:] = SPIBytes
 
-        result = self._writeRead(command, 8+numSPIBytes, [ 0xF8, 1+(numSPIBytes/2), 0x3A ])
+        result = self._writeRead(command, 8 + numSPIBytes, [0xF8, 1 + (numSPIBytes / 2), 0x3A])
 
         if result[6] != 0:
             raise LowlevelErrorException(result[6], "The spi command returned an error:\n    %s" % lowlevelErrorToString(result[6]))
 
-        return { 'NumSPIBytesTransferred' : result[7], 'SPIBytes' : result[8:] }
+        return {'NumSPIBytesTransferred': result[7], 'SPIBytes': result[8:]}
 
-    def asynchConfig(self, Update = True, UARTEnable = True, DesiredBaud  = 9600):
+    def asynchConfig(self, Update=True, UARTEnable=True, DesiredBaud=9600):
         """
         Name: UE9.asynchConfig(Update = True, UARTEnable = True,
                               DesiredBaud = 9600)
@@ -1380,27 +1380,27 @@ class UE9(Device):
         returns a dictionary:
         {
             'Update' : True means new parameters were written
-            'UARTEnable' : True means the UART is enabled
-            'BaudFactor' : The baud factor being used
+            'UARTEnable': True means the UART is enabled
+            'BaudFactor': The baud factor being used
         }
         """
 
-        command = [ 0 ] * 10
+        command = [0] * 10
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
         command[3] = 0x14
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #command[6] = 0x00
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # command[6] = 0x00
 
         if Update:
-            command[7] |= ( 1 << 7 )
+            command[7] |= (1 << 7)
         if UARTEnable:
-            command[7] |= ( 1 << 6 )
+            command[7] |= (1 << 6)
 
-        BaudFactor = (2**16) - 48000000/(2 * DesiredBaud)
+        BaudFactor = (2**16) - 48000000 / (2 * DesiredBaud)
         t = pack("<H", BaudFactor)
         command[8] = ord(t[0])
         command[9] = ord(t[1])
@@ -1431,8 +1431,8 @@ class UE9(Device):
 
         returns a dictionary:
         {
-            'NumAsynchBytesSent' : Number of Asynch Bytes Sent
-            'NumAsynchBytesInRXBuffer' : How many bytes are currently in the
+            'NumAsynchBytesSent': Number of Asynch Bytes Sent
+            'NumAsynchBytesInRXBuffer': How many bytes are currently in the
                                          RX buffer.
         }
         """
@@ -1442,20 +1442,20 @@ class UE9(Device):
         numBytes = len(AsynchBytes)
 
         oddPacket = False
-        if numBytes%2 != 0:
+        if numBytes % 2 != 0:
             AsynchBytes.append(0)
-            numBytes = numBytes+1
+            numBytes = numBytes + 1
             oddPacket = True
 
-        command = [ 0 ] * ( 8 + numBytes)
+        command = [0] * (8 + numBytes)
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 1 + ( numBytes/2 )
+        command[2] = 1 + (numBytes / 2)
         command[3] = 0x15
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #command[6] = 0x00
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # command[6] = 0x00
         command[7] = numBytes
         if oddPacket:
             command[7] = numBytes - 1
@@ -1464,9 +1464,9 @@ class UE9(Device):
 
         result = self._writeRead(command, 10, [0xF8, 0x02, 0x15])
 
-        return { 'NumAsynchBytesSent' : result[7], 'NumAsynchBytesInRXBuffer' : result[8] }
+        return {'NumAsynchBytesSent': result[7], 'NumAsynchBytesInRXBuffer': result[8]}
 
-    def asynchRX(self, Flush = False):
+    def asynchRX(self, Flush=False):
         """
         Name: UE9.asynchRX(Flush = False)
         Args: Flush, Set to True to flush
@@ -1476,29 +1476,29 @@ class UE9(Device):
 
         returns a dictonary:
         {
-            'AsynchBytes' : List of received bytes
-            'NumAsynchBytesInRXBuffer' : Number of AsynchBytes are in the RX
+            'AsynchBytes': List of received bytes
+            'NumAsynchBytesInRXBuffer': Number of AsynchBytes are in the RX
                                          Buffer.
         }
         """
-        command = [ 0 ] * 8
+        command = [0] * 8
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
         command[3] = 0x16
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
-        #command[6] = 0x00
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
+        # command[6] = 0x00
         if Flush:
             command[7] = 1
 
 
         result = self._writeRead(command, 40, [0xF8, 0x11, 0x16])
 
-        return { 'AsynchBytes' : result[8:], 'NumAsynchBytesInRXBuffer' : result[7] }
+        return {'AsynchBytes': result[8:], 'NumAsynchBytesInRXBuffer': result[7]}
 
-    def i2c(self, Address, I2CBytes, EnableClockStretching = False, NoStopWhenRestarting = False, ResetAtStart = False, SpeedAdjust = 0, SDAPinNum = 1, SCLPinNum = 0, NumI2CBytesToReceive = 0, AddressByte = None):
+    def i2c(self, Address, I2CBytes, EnableClockStretching=False, NoStopWhenRestarting=False, ResetAtStart=False, SpeedAdjust=0, SDAPinNum=1, SCLPinNum=0, NumI2CBytesToReceive=0, AddressByte=None):
         """
         Name: UE9.i2c(Address, I2CBytes, ResetAtStart = False, EnableClockStretching = False, SpeedAdjust = 0, SDAPinNum = 0, SCLPinNum = 1, NumI2CBytesToReceive = 0, AddressByte = None)
         Args: Address, the address (not shifted over)
@@ -1520,14 +1520,14 @@ class UE9(Device):
             numBytes = numBytes + 1
             oddPacket = True
 
-        command = [0] * (14+numBytes)
+        command = [0] * (14 + numBytes)
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
-        command[2] = 4 + (numBytes//2)
+        command[2] = 4 + (numBytes // 2)
         command[3] = 0x3B
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         if ResetAtStart:
             command[6] |= (1 << 1)
         if NoStopWhenRestarting:
@@ -1553,7 +1553,7 @@ class UE9(Device):
             NumI2CBytesToReceive = NumI2CBytesToReceive + 1
             oddResponse = True
 
-        result = self._writeRead(command, 12 + NumI2CBytesToReceive, [0xF8, (3 + (NumI2CBytesToReceive/2)), 0x3B])
+        result = self._writeRead(command, 12 + NumI2CBytesToReceive, [0xF8, (3 + (NumI2CBytesToReceive / 2)), 0x3B])
 
         if len(result) > 12:
             if oddResponse:
@@ -1563,7 +1563,7 @@ class UE9(Device):
         else:
             return {'AckArray': result[8:], 'I2CBytes': []}
 
-    def sht1x(self, DataPinNum = 0, ClockPinNum = 1, SHTOptions = 0xc0):
+    def sht1x(self, DataPinNum=0, ClockPinNum=1, SHTOptions=0xc0):
         """
         Name: UE9.sht1x(DataPinNum = 0, ClockPinNum = 1, SHTOptions = 0xc0)
         Args: DataPinNum, Which pin is the Data line
@@ -1577,37 +1577,37 @@ class UE9(Device):
         Desc: Reads temperature and humidity from a Sensirion SHT1X sensor.
               Section 5.3.21 of the User's Guide.
         """
-        command = [ 0 ] * 10
+        command = [0] * 10
 
-        #command[0] = Checksum8
+        # command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
         command[3] = 0x39
-        #command[4] = Checksum16 (LSB)
-        #command[5] = Checksum16 (MSB)
+        # command[4] = Checksum16 (LSB)
+        # command[5] = Checksum16 (MSB)
         command[6] = DataPinNum
         command[7] = ClockPinNum
-        #command[8] = Reserved
+        # command[8] = Reserved
         command[9] = SHTOptions
 
-        result = self._writeRead(command, 16, [ 0xF8, 0x05, 0x39])
+        result = self._writeRead(command, 16, [0xF8, 0x05, 0x39])
 
-        val = (result[11]*256) + result[10]
-        temp = -39.60 + 0.01*val
+        val = (result[11] * 256) + result[10]
+        temp = -39.60 + 0.01 * val
 
-        val = (result[14]*256) + result[13]
-        humid = -4 + 0.0405*val + -.0000028*(val*val)
-        humid = (temp - 25)*(0.01 + 0.00008*val) + humid
+        val = (result[14] * 256) + result[13]
+        humid = -4 + 0.0405 * val + -.0000028 * (val * val)
+        humid = (temp - 25) * (0.01 + 0.00008 * val) + humid
 
-        return { 'StatusReg' : result[8], 'StatusCRC' : result[9], 'Temperature' : temp, 'TemperatureCRC' : result[12], 'Humidity' : humid, 'HumidityCRC' : result[15] }
+        return {'StatusReg': result[8], 'StatusCRC': result[9], 'Temperature': temp, 'TemperatureCRC': result[12], 'Humidity': humid, 'HumidityCRC': result[15]}
 
-    def getAIN(self, channel, BipGain = 0x00, Resolution = 12, SettlingTime = 0):
+    def getAIN(self, channel, BipGain=0x00, Resolution=12, SettlingTime=0):
         """
         Name: UE9.getAIN(channel, BipGain = 0x00, Resolution = 12,
                          SettlingTime = 0)
         """
-        bits = self.singleIO(4, channel, BipGain = BipGain, Resolution = Resolution, SettlingTime = SettlingTime)
-        return self.binaryToCalibratedAnalogVoltage(bits["AIN%s"%channel], BipGain, Resolution)
+        bits = self.singleIO(4, channel, BipGain=BipGain, Resolution=Resolution, SettlingTime=SettlingTime)
+        return self.binaryToCalibratedAnalogVoltage(bits["AIN%s" % channel], BipGain, Resolution)
 
     def getTemperature(self):
         """
@@ -1616,10 +1616,10 @@ class UE9(Device):
         if self.calData is None:
             self.getCalibrationData()
 
-        bits = self.singleIO(4, 133, BipGain = 0x00, Resolution = 12, SettlingTime = 0)
+        bits = self.singleIO(4, 133, BipGain=0x00, Resolution=12, SettlingTime=0)
         return self.binaryToCalibratedAnalogTemperature(bits["AIN133"])
 
-    def binaryToCalibratedAnalogVoltage(self, bits, gain, resolution = 0):
+    def binaryToCalibratedAnalogVoltage(self, bits, gain, resolution=0):
         """
         Name: UE9.binaryToCalibratedAnalogVoltage(bits, gain, resolution = 0)
         Args: bits, the binary value to be converted
@@ -1643,7 +1643,7 @@ class UE9(Device):
                 slope = self.calData['AINSlopes'][str(gain)]
                 offset = self.calData['AINOffsets'][str(gain)]
         else:
-            #Normal and hi-res nominal calibration values are the same.
+            # Normal and hi-res nominal calibration values are the same.
             slope = DEFAULT_CAL_CONSTANTS['AINSlopes'][str(gain)]
             offset = DEFAULT_CAL_CONSTANTS['AINOffsets'][str(gain)]
 
@@ -1655,7 +1655,7 @@ class UE9(Device):
         else:
             return bits * DEFAULT_CAL_CONSTANTS['TempSlope']
 
-    def voltageToDACBits(self, volts, dacNumber = 0):
+    def voltageToDACBits(self, volts, dacNumber=0):
         """
         Name: UE9.voltageToDACBits(volts, dacNumber = 0)
         Args: volts, the voltage you would like to set the DAC to.
@@ -1685,12 +1685,12 @@ class UE9(Device):
               if the device is a UE9 or not. It also makes calls to
               readMem, so please don't call this while streaming.
         """
-        ainslopes = { '0' : None, '1' : None, '2' : None, '3' : None, '8' : None }
-        ainoffsets = { '0' : None, '1' : None, '2' : None, '3' : None, '8' : None }
-        proainslopes = { '0' : None, '8' : None }
-        proainoffsets = { '0' : None, '8' : None }
-        dacslopes = { '0' : None, '1' : None }
-        dacoffsets = { '0' : None, '1' : None }
+        ainslopes = {'0': None, '1': None, '2': None, '3': None, '8': None}
+        ainoffsets = {'0': None, '1': None, '2': None, '3': None, '8': None}
+        proainslopes = {'0': None, '8': None}
+        proainoffsets = {'0': None, '8': None}
+        dacslopes = {'0': None, '1': None}
+        dacoffsets = {'0': None, '1': None}
 
         tempslope = None
 
@@ -1787,15 +1787,15 @@ class UE9(Device):
         results['TMR5ValueL'] = defaults[5]
         results['TMR5ValueH'] = defaults[6]
 
-        results['DAC0'] = unpack( "<H", pack("BB", *defaults[16:18]) )[0]
+        results['DAC0'] = unpack("<H", pack("BB", *defaults[16:18]))[0]
 
-        results['DAC1'] = unpack( "<H", pack("BB", *defaults[20:22]) )[0]
+        results['DAC1'] = unpack("<H", pack("BB", *defaults[20:22]))[0]
 
         defaults = self.readDefaults(3)
 
         for i in range(14):
             results["AIN%sRes" % i] = defaults[i]
-            results["AIN%sBPGain" % i] = defaults[i+16]
+            results["AIN%sBPGain" % i] = defaults[i + 16]
 
         defaults = self.readDefaults(4)
         for i in range(14):
@@ -1843,14 +1843,14 @@ class UE9(Device):
         section = "FIOs"
         parser.add_section(section)
 
-        parser.set(section, "FIO Directions", str( self.readRegister(6750) ))
-        parser.set(section, "FIO States", str( self.readRegister(6700) ))
-        parser.set(section, "EIO Directions", str( self.readRegister(6751) ))
-        parser.set(section, "EIO States", str( self.readRegister(6701) ))
-        parser.set(section, "CIO Directions", str( self.readRegister(6752) ))
-        parser.set(section, "CIO States", str( self.readRegister(6702) ))
-        #parser.set(section, "MIOs Directions", str( self.readRegister(50591) ))
-        #parser.set(section, "MIOs States", str( self.readRegister(50591) ))
+        parser.set(section, "FIO Directions", str(self.readRegister(6750)))
+        parser.set(section, "FIO States", str(self.readRegister(6700)))
+        parser.set(section, "EIO Directions", str(self.readRegister(6751)))
+        parser.set(section, "EIO States", str(self.readRegister(6701)))
+        parser.set(section, "CIO Directions", str(self.readRegister(6752)))
+        parser.set(section, "CIO States", str(self.readRegister(6702)))
+        # parser.set(section, "MIOs Directions", str( self.readRegister(50591)))
+        # parser.set(section, "MIOs States", str( self.readRegister(50591)))
 
         # DACs
         section = "DACs"
@@ -1879,15 +1879,15 @@ class UE9(Device):
 
         nte = self.readRegister(50501)
         cm = self.readRegister(50502)
-        ec0 = bool( cm & 1 )
-        ec1 = bool( (cm >> 1) & 1 )
+        ec0 = bool(cm & 1)
+        ec1 = bool((cm >> 1) & 1)
 
-        parser.set(section, "NumberTimersEnabled", str(nte) )
-        parser.set(section, "Counter0Enabled", str(ec0) )
-        parser.set(section, "Counter1Enabled", str(ec1) )
+        parser.set(section, "NumberTimersEnabled", str(nte))
+        parser.set(section, "Counter0Enabled", str(ec0))
+        parser.set(section, "Counter1Enabled", str(ec1))
 
         for i in range(nte):
-            mode, value = self.readRegister(7100 + (i*2), numReg = 2, format = ">HH")
+            mode, value = self.readRegister(7100 + (i * 2), numReg=2, format=">HH")
             parser.set(section, "Timer%s Mode" % i, str(mode))
             parser.set(section, "Timer%s Value" % i, str(value))
 
@@ -1911,10 +1911,10 @@ class UE9(Device):
                     raise Exception("Not a UE9 Config file.")
 
             if parser.has_option(section, "local id"):
-                self.commConfig( LocalID = parser.getint(section, "local id"))
+                self.commConfig(LocalID=parser.getint(section, "local id"))
 
             if parser.has_option(section, "name"):
-                self.setName( parser.get(section, "name") )
+                self.setName(parser.get(section, "name"))
 
         # Comm Config settings
         section = "Communication"
@@ -1944,7 +1944,7 @@ class UE9(Device):
             if parser.has_option(section, "portB"):
                 portB = parser.getint(section, "portB")
 
-            self.commConfig( DHCPEnabled = DHCPEnabled, IPAddress = ipAddress, Subnet = subnet, Gateway = gateway, PortA = portA, PortB = portB )
+            self.commConfig(DHCPEnabled=DHCPEnabled, IPAddress=ipAddress, Subnet=subnet, Gateway=gateway, PortA=portA, PortB=portB)
 
 
         # Set FIOs:
@@ -1975,16 +1975,16 @@ class UE9(Device):
             bitmask = 0xff00
 
             # FIO State/Dir
-            self.writeRegister(6700, bitmask + fiostates )
-            self.writeRegister(6750, bitmask + fiodirs )
+            self.writeRegister(6700, bitmask + fiostates)
+            self.writeRegister(6750, bitmask + fiodirs)
 
             # EIO State/Dir
-            self.writeRegister(6701, bitmask + eiostates )
-            self.writeRegister(6751, bitmask + eiodirs )
+            self.writeRegister(6701, bitmask + eiostates)
+            self.writeRegister(6751, bitmask + eiodirs)
 
             # CIO State/Dir
-            self.writeRegister(6702, bitmask + ciostates )
-            self.writeRegister(6752, bitmask + ciodirs )
+            self.writeRegister(6702, bitmask + ciostates)
+            self.writeRegister(6752, bitmask + ciodirs)
 
 
         # Set DACs:
@@ -2015,12 +2015,12 @@ class UE9(Device):
                 self.writeRegister(50501, nte)
 
             if parser.has_option(section, "Counter0Enabled"):
-                cm = (self.readRegister(50502) & 2) # 0b10
+                cm = (self.readRegister(50502) & 2)  # 0b10
                 c0e = parser.getboolean(section, "Counter0Enabled")
                 self.writeRegister(50502, cm + int(c0e))
 
             if parser.has_option(section, "Counter1Enabled"):
-                cm = (self.readRegister(50502) & 1) # 0b01
+                cm = (self.readRegister(50502) & 1)  # 0b01
                 c1e = parser.getboolean(section, "Counter1Enabled")
                 self.writeRegister(50502, (int(c1e) << 1) + 1)
 
@@ -2036,4 +2036,4 @@ class UE9(Device):
                     if parser.has_option(section, "timer%s value"):
                         value = parser.getint(section, "timer%s mode")
 
-                    self.writeRegister(7100 + (i*2), [mode, value])
+                    self.writeRegister(7100 + (i * 2), [mode, value])

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -7,7 +7,7 @@ Desc: Defines the UE9 class, which makes working with a UE9 much easier. All of
 
 To learn about the low-level functions, please see Section 5.2 of the UE9 User's Guide:
 
-http://labjack.com/support/ue9/users-guide/5.2 
+http://labjack.com/support/ue9/users-guide/5.2
 """
 import collections
 import datetime
@@ -16,9 +16,9 @@ import socket
 import warnings
 
 try:
-  import ConfigParser
+    import ConfigParser
 except ImportError: # Python 3
-  import configparser as ConfigParser
+    import configparser as ConfigParser
 
 from struct import pack, unpack
 
@@ -40,21 +40,21 @@ from LabJackPython import (
 
 def openAllUE9():
     """
-    A helpful function which will open all the connected UE9s. Returns a 
+    A helpful function which will open all the connected UE9s. Returns a
     dictionary where the keys are the serialNumber, and the value is the device
     object.
     """
     returnDict = dict()
-    
+
     for i in range(deviceCount(9)):
         d = UE9(firstFound = False, devNumber = i+1)
         returnDict[str(d.serialNumber)] = d
-        
+
     return returnDict
 
 def parseIpAddress(bytes):
     return "%s.%s.%s.%s" % (bytes[3], bytes[2], bytes[1], bytes[0] )
-    
+
 def unpackInt(bytes):
     return unpack("<I", pack("BBBB", *bytes))[0]
 
@@ -78,11 +78,11 @@ class UE9(Device):
         Name: UE9.__init__(self)
         Args: debug, True for debug information
         Desc: Your basic constructor.
-        
+
         >>> myUe9 = ue9.UE9()
         """
         Device.__init__(self, None, devType = 9)
-        
+
         self.debug = debug
         self.calData = None
         self.controlFWVersion = self.commFWVersion = None
@@ -90,7 +90,7 @@ class UE9(Device):
 
         if autoOpen:
             self.open(**kargs)
-    
+
     def open(self, firstFound = True, serial = None, ipAddress = None, localId = None, devNumber = None, ethernet=False, handleOnly = False, LJSocket = None):
         """
         Name: UE9.open(firstFound = True, ipAddress = None, localId = None, devNumber = None, ethernet=False)
@@ -103,19 +103,19 @@ class UE9(Device):
               handleOnly, if True, LabJackPython will only open a handle
               LJSocket, set to "<ip>:<port>" to connect to LJSocket
         Desc: Opens the UE9.
-        
+
         >>> myUe9 = ue9.UE9(autoOpen = False)
         >>> myUe9.open()
         """
         self.ethernet = ethernet
         Device.open(self, 9, Ethernet = ethernet, firstFound = firstFound, serial = serial, localId = localId, devNumber = devNumber, ipAddress = ipAddress, handleOnly = handleOnly, LJSocket = LJSocket)
-        
+
     def commConfig(self, LocalID = None, IPAddress = None, Gateway = None, Subnet = None, PortA = None, PortB = None, DHCPEnabled = None):
         """
         Name: UE9.commConfig(LocalID = None, IPAddress = None, Gateway = None,
                 Subnet = None, PortA = None, PortB = None, DHCPEnabled = None)
         Args: LocalID, Set the LocalID
-              IPAddress, Set the IPAddress 
+              IPAddress, Set the IPAddress
               Gateway, Set the Gateway
               Subnet, Set the Subnet
               PortA, Set Port A
@@ -123,7 +123,7 @@ class UE9(Device):
               DHCPEnabled, True = Enabled, False = Disabled
         Desc: Writes and reads various configuration settings associated
               with the Comm processor. Section 5.2.1 of the User's Guide.
-        
+
         >>> myUe9 = ue9.UE9()
         >>> myUe9.commConfig()
         {'CommFWVersion': '1.47',
@@ -141,7 +141,7 @@ class UE9(Device):
          'Subnet': '255.255.255.0'}
         """
         command = [ 0 ] * 38
-        
+
         #command[0] = Checksum8
         command[1] = 0x78
         command[2] = 0x10
@@ -153,34 +153,34 @@ class UE9(Device):
         if LocalID is not None:
             command[6] |= 1
             command[8] = LocalID
-        
+
         if IPAddress is not None:
             command[6] |= (1 << 2)
             ipbytes = IPAddress.split('.')
             ipbytes = [ int(x) for x in ipbytes ]
             ipbytes.reverse()
             command[10:14] = ipbytes
-        
+
         if Gateway is not None:
             command[6] |= (1 << 3)
             gwbytes = Gateway.split('.')
             gwbytes = [ int(x) for x in gwbytes ]
             gwbytes.reverse()
             command[14:18] = gwbytes
-        
+
         if Subnet is not None:
             command[6] |= (1 << 4)
             snbytes = Subnet.split('.')
             snbytes = [ int(x) for x in snbytes ]
             snbytes.reverse()
             command[18:21] = snbytes
-            
+
         if PortA is not None:
             command[6] |= (1 << 5)
             t = pack("<H", PortA)
             command[22] = ord(t[0])
             command[23] = ord(t[1])
-        
+
         if PortB is not None:
             command[6] |= (1 << 5)
             t = pack("<H", PortB)
@@ -191,7 +191,7 @@ class UE9(Device):
             command[6] |= (1 << 6)
             if DHCPEnabled:
                 command[26] = 1
-        
+
         result = self._writeRead(command, 38, [], checkBytes = False)
 
         if len(result) == 0:
@@ -214,9 +214,9 @@ class UE9(Device):
         self.productId = result[27]
 
         self.macAddress = "%02X:%02X:%02X:%02X:%02X:%02X" % (result[33], result[32], result[31], result[30], result[29], result[28])
-        
+
         self.serialNumber = unpack("<I", pack("BBBB", result[28], result[29], result[30], 0x10))[0]
-        
+
         self.hwVersion = "%s.%02d" % (result[35], result[34])
         self.commFWVersion = "%s.%02d" % (result[37], result[36])
         self.firmwareVersion = [self.controlFWVersion, self.commFWVersion]
@@ -242,7 +242,7 @@ class UE9(Device):
         Desc: Sends a UDP Broadcast packet and returns a dictionary of the
               result. The dictionary contains all the things that are in the
               commConfig dictionary.
-        
+
         >>> myUe9 = ue9.UE9()
         >>> myUe9.discoveryUDP()
         {'192.168.1.114': {'CommFWVersion': '1.47', ... },
@@ -252,7 +252,7 @@ class UE9(Device):
         host = '255.255.255.255'
         port = 52362
         addr = (host,port)
-        
+
         sndBuffer = [0] * 6
         sndBuffer[0] = 0x22
         sndBuffer[1] = 0x78
@@ -260,18 +260,18 @@ class UE9(Device):
         sndBuffer[3] = 0xA9
         sndBuffer[4] = 0x00
         sndBuffer[5] = 0x00
-    
+
         packFormat = "B" * len(sndBuffer)
         tempString = pack(packFormat, *sndBuffer)
-        
+
         s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-    
+
         s.sendto(tempString, addr)
-        
+
         inputs = [s]
 
         ue9s = {}
-        
+
         listen = True
         while listen:
             #We will wait 2 seconds for a response from a Ue9
@@ -283,12 +283,12 @@ class UE9(Device):
                     ue9s[addr[0]] = data
                     listen = True
         s.close()
-        
+
         for ip, data in ue9s.items():
             data = list(unpack("B"*38, data))
             ue9 = { 'LocalID' : data[8], 'PowerLevel' : data[9] , 'IPAddress' : parseIpAddress(data[10:14]), 'Gateway' : parseIpAddress(data[14:18]), 'Subnet' : parseIpAddress(data[18:23]), 'PortA' : unpack("<H", pack("BB", *data[22:24]))[0], 'PortB' : unpack("<H", pack("BB", *data[24:26]))[0], 'DHCPEnabled' : bool(data[26]), 'ProductID' : data[27], 'MACAddress' : "%02X:%02X:%02X:%02X:%02X:%02X" % (data[33], data[32], data[31], data[30], data[29], data[28]), 'SerialNumber' : unpack("<I", pack("BBBB", data[28], data[29], data[30], 0x10))[0], 'HWVersion' : "%s.%02d" % (data[35], data[34]), 'CommFWVersion' : "%s.%02d" % (data[37], data[36])}
             ue9s[ip] = ue9
-        
+
         return ue9s
 
     def ipAddressFilter(self, Write = 0, IP0 = None, IP1 = None, IP2 = None, IP3 = None, IP4 = None):
@@ -321,7 +321,7 @@ class UE9(Device):
 
         if Write != 0:
             command[6] = 1
-        
+
         ips = [IP0, IP1, IP2, IP3, IP4]
         startbyte = 8
         for ip in ips:
@@ -372,7 +372,7 @@ class UE9(Device):
               DAC1Enable, True = DAC1 Enabled, False = DAC1 Disabled
               DAC1, The default value for DAC1
         Desc: Configures various parameters associated with the Control
-              processor. Affects only the power-up values, not current 
+              processor. Affects only the power-up values, not current
               state. See section 5.3.2 of the User's Guide.
 
         >>> myUe9 = ue9.UE9()
@@ -502,7 +502,7 @@ class UE9(Device):
          'TimerC': 0}
         """
         command = [ 0 ] * 34
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x0E
@@ -521,23 +521,23 @@ class UE9(Device):
         command[14] = MIOMask
         command[15] = (MIODirection & 7) << 4
         command[15] |= (MIOState & 7 )
-        
+
         if DAC0Update:
             if DAC0Enabled:
                 command[17] = 1 << 7
             command[17] |= 1 << 6
-            
+
             command[16] = DAC0 & 0xff
             command[17] |= (DAC0 >> 8) & 0xf
-        
+
         if DAC1Update:
             if DAC1Enabled:
                 command[19] = 1 << 7
             command[19] |= 1 << 6
-            
+
             command[18] = DAC1 & 0xff
             command[19] |= (DAC1 >> 8) & 0xf
-        
+
         command[20] = AINMask & 0xff
         command[21] = (AINMask >> 8) & 0xff
         command[22] = AIN14ChannelNumber
@@ -552,15 +552,15 @@ class UE9(Device):
         command[31] = AIN11_10_BipGain
         command[32] = AIN13_12_BipGain
         command[33] = AIN15_14_BipGain
-        
+
         result = self._writeRead(command, 64, [ 0xF8, 0x1D, 0x00], checkBytes = False)
-        
+
         returnDict = { 'FIODir' : result[6], 'FIOState' : result[7], 'EIODir' : result[8], 'EIOState' : result[9], 'CIODir' : (result[10] >> 4) & 0xf, 'CIOState' : result[10] & 0xf, 'MIODir' : (result[11] >> 4) & 7, 'MIOState' : result[11] & 7, 'Counter0' : unpackInt(result[44:48]), 'Counter1' : unpackInt(result[48:52]), 'TimerA' : unpackInt(result[52:56]), 'TimerB' : unpackInt(result[56:60]), 'TimerC' : unpackInt(result[60:]) }
-        
+
         """
-'AIN0' : b2c(unpackShort(result[12:14])), 'AIN1' : unpackShort(result[14:16]), 'AIN2' : unpackShort(result[16:18]), 'AIN3' : unpackShort(result[18:20]), 'AIN4' : unpackShort(result[20:22]), 'AIN5' : unpackShort(result[22:24]), 'AIN6' : unpackShort(result[24:26]), 'AIN7' : unpackShort(result[26:28]), 'AIN8' : unpackShort(result[28:30]), 'AIN9' : unpackShort(result[30:32]), 'AIN10' : unpackShort(result[32:34]), 'AIN11' : unpackShort(result[34:36]), 'AIN12' : unpackShort(result[36:38]), 'AIN13' : unpackShort(result[38:40]), 'AIN14' : unpackShort(result[40:42]), 'AIN15' : unpackShort(result[42:44]), 
+'AIN0' : b2c(unpackShort(result[12:14])), 'AIN1' : unpackShort(result[14:16]), 'AIN2' : unpackShort(result[16:18]), 'AIN3' : unpackShort(result[18:20]), 'AIN4' : unpackShort(result[20:22]), 'AIN5' : unpackShort(result[22:24]), 'AIN6' : unpackShort(result[24:26]), 'AIN7' : unpackShort(result[26:28]), 'AIN8' : unpackShort(result[28:30]), 'AIN9' : unpackShort(result[30:32]), 'AIN10' : unpackShort(result[32:34]), 'AIN11' : unpackShort(result[34:36]), 'AIN12' : unpackShort(result[36:38]), 'AIN13' : unpackShort(result[38:40]), 'AIN14' : unpackShort(result[40:42]), 'AIN15' : unpackShort(result[42:44]),
         """
-        
+
         b2c = self.binaryToCalibratedAnalogVoltage
         g = 0
         for i in range(16):
@@ -571,7 +571,7 @@ class UE9(Device):
                 gain = (command[26 + g] >> 4) & 0xf
                 g += 1
             returnDict["AIN%s" % i] = b2c(bits, gain)
-        
+
         return returnDict
 
     digitalPorts = [ 'FIO', 'EIO', 'CIO', 'MIO' ]
@@ -582,18 +582,18 @@ class UE9(Device):
         Desc: An alternative to Feedback, is this function which writes or
               reads a single output or input. See section 5.3.4 of the User's
               Guide.
-              
+
         >>> myUe9 = ue9.UE9()
         >>> myUe9.singleIO(1, 0, Dir = 1, State = 0)
         {'FIO0 Direction': 1, 'FIO0 State': 0}
         """
         command = [ 0 ] * 8
-        
+
         #command[0] = Checksum8
         command[1] = 0xA3
         command[2] = IOType
         command[3] = Channel
-        
+
         if IOType == 0:
             #Digital Bit Read
             pass
@@ -625,9 +625,9 @@ class UE9(Device):
                 raise LabJackException("Need to specify a DAC Value")
             command[4] = DAC & 0xff
             command[5] = (DAC >> 8) & 0xf
-        
+
         result = self._writeRead(command, 8, [ 0xA3 ], checkBytes = False)
-        
+
         if result[2] == 0:
             #Digital Bit Read
             return { "FIO%s State" % result[3] : result[5], "FIO%s Direction" % result[3] : result[4] }
@@ -648,7 +648,7 @@ class UE9(Device):
             #Analog Out
             dac = (result[6] << 16) + (result[5] << 8) + result[4]
             return { "DAC%s" % result[3] : dac }
-    
+
     def timerCounter(self, TimerClockDivisor=0, UpdateConfig=False, NumTimersEnabled=0, Counter0Enabled=False, Counter1Enabled=False, TimerClockBase=LJ_tcSYS, ResetTimer0=False, ResetTimer1=False, ResetTimer2=False, ResetTimer3=False, ResetTimer4=False, ResetTimer5=False, ResetCounter0=False, ResetCounter1=False, Timer0Mode=None, Timer0Value=None, Timer1Mode=None, Timer1Value=None, Timer2Mode=None, Timer2Value=None, Timer3Mode=None, Timer3Value=None, Timer4Mode=None, Timer4Value=None, Timer5Mode=None, Timer5Value=None):
         """
         Name: UE9.timerCounter(TimerClockDivisor=0, UpdateConfig=False,
@@ -664,7 +664,7 @@ class UE9(Device):
                                Timer3Mode=None, Timer3Value=None,
                                Timer4Mode=None, Timer4Value=None,
                                Timer5Mode=None, Timer5Value=None)
-        
+
         Args: TimerClockDivisor, The timer clock is divided by this value, or
                                  divided by 256 if this value is 0. The
                                  UpdateConfig bit must be set to change this
@@ -687,7 +687,7 @@ class UE9(Device):
               Timer#Value, Only updates if UpdateReset is True. The meaning of
                            this parameter varies with the timer mode. See
                            Section 2.10 for further information.
-        
+
         Desc: Enables, configures, and reads the counters and timers. See
               section 5.3.5 of the User's Guide for more information.
         >>> dev = UE9()
@@ -787,18 +787,18 @@ class UE9(Device):
         """
         Name: UE9.readMem(BlockNum)
         Args: BlockNum, which block to read
-        Desc: Reads 1 block (128 bytes) from the non-volatile user or 
+        Desc: Reads 1 block (128 bytes) from the non-volatile user or
               calibration memory. Please read section 5.3.10 of the user's
               guide before you do something you may regret.
-        
+
         >>> myUE9 = UE9()
         >>> myUE9.readMem(0)
         [ < userdata stored in block 0 > ]
-        
+
         NOTE: Do not call this function while streaming.
         """
         command = [ 0 ] * 8
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
@@ -807,9 +807,9 @@ class UE9(Device):
         #command[5] = Checksum16 (MSB)
         command[6] = 0x00
         command[7] = BlockNum
-        
+
         result = self._writeRead(command, 136, [ 0xF8, 0x41, 0x2A ])
-        
+
         return result[8:]
 
     def writeMem(self, BlockNum, Data):
@@ -817,20 +817,20 @@ class UE9(Device):
         Name: UE9.writeMem(BlockNum, Data)
         Args: BlockNum, which block to write
               Data, a list of bytes to write
-        Desc: Writes 1 block (128 bytes) from the non-volatile user or 
+        Desc: Writes 1 block (128 bytes) from the non-volatile user or
               calibration memory. Please read section 5.3.11 of the user's
               guide before you do something you may regret.
-        
+
         >>> myUE9 = UE9()
         >>> myUE9.writeMem(0, [ < userdata to be stored in block 0 > ])
-        
+
         NOTE: Do not call this function while streaming.
         """
         if not isinstance(Data, list):
             raise LabJackException("Data must be a list of bytes")
-        
+
         command = [ 0 ] * 136
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x41
@@ -850,17 +850,17 @@ class UE9(Device):
         Desc: The UE9 uses flash memory that must be erased before writing.
               Please read section 5.2.12 of the user's guide before you do
               something you may regret.
-        
+
         >>> myUE9 = UE9()
         >>> myUE9.eraseMem()
-        
+
         NOTE: Do not call this function while streaming.
         """
         if not isinstance(EraseCal, bool):
             raise LabJackException("EraseCal must be a Boolean value (True or False).")
-        
+
         command = [ 0 ] * 8
-            
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
@@ -874,7 +874,7 @@ class UE9(Device):
         else:
             command[6] = 0x00
             command[7] = 0x00
-        
+
         self._writeRead(command, 8, [0xF8, 0x01, command[3]])
 
     def streamClearData(self):
@@ -913,7 +913,7 @@ class UE9(Device):
                                SampleFrequency = None, ScanFrequency = None)
         Args: NumChannels, the number of channels to stream
               Resolution, the resolution of the samples (12 - 16)
-              SettlingTime, the settling time to be used 
+              SettlingTime, the settling time to be used
                             (SettlingTime * 5 microseconds)
               ChannelNumbers, a list of channel numbers to stream
               ChannelOptions, a list of channel options bytes.
@@ -921,11 +921,11 @@ class UE9(Device):
                                   0 = Unipolar Gain 1, 1 = Unipolar Gain 2,
                                   2 = Unipolar Gain 4, 3 = Unipolar Gain 8,
                                   8 = Bipolar Gain 1
-              EnableExternalScanTrigger, enable external scan trigger.  The UE9 
+              EnableExternalScanTrigger, enable external scan trigger.  The UE9
                                          scans the table each time it detects a
                                          falling edge on Counter 1 (slave mode).
               EnableScanPulseOutput, enable scan pulse output.  Counter 1 will
-                                     pulse low just before every scan (master 
+                                     pulse low just before every scan (master
                                      mode).
 
               Set:
@@ -1196,7 +1196,7 @@ class UE9(Device):
               numBytes, the number of bytes per packet
         Desc: Breaks stream data into individual channels and applies
               calibrations.
-              
+
         >>> reading = d.streamData(convert = False)
         >>> print(processStreamData(reading['result']))
         defaultDict(list, {'AIN0': [3.123, 3.231, 3.232, ...]})
@@ -1243,42 +1243,42 @@ class UE9(Device):
         Desc: Writes the configuration of the watchdog.
         """
         command = [ 0 ] * 16
-        
+
         command[1] = 0xF8
         command[2] = 0x05
         command[3] = 0x09
-        
+
         if ResetCommonTimeout:
             command[7] |= (1 << 6)
-        
+
         if ResetControlonTimeout:
             command[7] |= (1 << 5)
-        
+
         if UpdateDigitalIOB:
             command[7] |= (1 << 4)
-        
+
         if UpdateDigitalIOA:
             command[7] |= (1 << 3)
-        
+
         if UpdateDAC1onTimeout:
             command[7] |= (1 << 1)
-        
+
         if UpdateDAC0onTimeout:
             command[7] |= (1 << 0)
-        
+
         t = pack("<H", TimeoutPeriod)
         command[8] = ord(t[0])
         command[9] = ord(t[1])
-        
+
         command[10] = DIOConfigA
         command[11] = DIOConfigB
-        
+
         command[12] = DAC0 & 0xff
         command[13] = (int(DAC0Enabled) << 7) + ((DAC0 >> 8) & 0xf)
-        
+
         command[14] = DAC1 & 0xff
         command[15] = (int(DAC1Enabled) << 7) + ((DAC1 >> 8) & 0xf)
-        
+
         result = self._writeRead(command, 8, [0xF8, 0x01, 0x09])
 
         return { 'UpdateDAC0onTimeout' : bool(result[7]& 1), 'UpdateDAC1onTimeout' : bool((result[7] >> 1) & 1), 'UpdateDigitalIOAonTimeout' : bool((result[7] >> 3) & 1), 'UpdateDigitalIOBonTimeout' : bool((result[7] >> 4) & 1), 'ResetControlOnTimeout' : bool((result[7] >> 5) & 1), 'ResetCommOnTimeout' : bool((result[7] >> 6) & 1) }
@@ -1293,7 +1293,7 @@ class UE9(Device):
         command[1] = 0xF8
         command[2] = 0x00
         command[3] = 0x09
-        
+
         command = setChecksum8(command, 6)
 
         result = self._writeRead(command, 16, [0xF8, 0x05, 0x09], checksum = False)
@@ -1304,13 +1304,13 @@ class UE9(Device):
         Name: UE9.spi(SPIBytes, AutoCS=True, DisableDirConfig = False,
                      SPIMode = 'A', SPIClockFactor = 0, CSPinNum = 1,
                      CLKPinNum = 0, MISOPinNum = 3, MOSIPinNum = 2)
-        
+
         Args: SPIBytes, a list of bytes to be transferred.
               See Section 5.3.16 of the user's guide.
-        
+
         Desc: Sends and receives serial data using SPI synchronous
               communication.
-        
+
         NOTE: The return has been changed to a dictionary with
               NumSPIBytesTransferred and SPIBytes.  The keyword
               argument CSPinNum was named CSPINNum in old versions.
@@ -1321,35 +1321,35 @@ class UE9(Device):
         if CSPINNum is not None:
             warnings.warn("CSPINNum is deprecated, use CSPinNum instead", DeprecationWarning)
             CSPinNum = CSPINNum
-        
+
         numSPIBytes = len(SPIBytes)
-        
+
         oddPacket = False
         if numSPIBytes%2 != 0:
             SPIBytes.append(0)
             numSPIBytes = numSPIBytes + 1
             oddPacket = True
-        
+
         command = [ 0 ] * (13 + numSPIBytes)
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 4 + (numSPIBytes/2)
         command[3] = 0x3A
         #command[4] = Checksum16 (LSB)
         #command[5] = Checksum16 (MSB)
-        
+
         if AutoCS:
             command[6] |= (1 << 7)
         if DisableDirConfig:
             command[6] |= (1 << 6)
-        
+
         spiModes = ('A', 'B', 'C', 'D')
         try:
             command[6] |= ( spiModes.index(SPIMode) & 3 )
         except ValueError:
             raise LabJackException("Invalid SPIMode %r, valid modes are: %r" % (SPIMode, spiModes))
-        
+
         command[7] = SPIClockFactor
         #command[8] = Reserved
         command[9] = CSPinNum
@@ -1359,11 +1359,11 @@ class UE9(Device):
         command[13] = numSPIBytes
         if oddPacket:
             command[13] = numSPIBytes - 1
-        
+
         command[14:] = SPIBytes
-        
+
         result = self._writeRead(command, 8+numSPIBytes, [ 0xF8, 1+(numSPIBytes/2), 0x3A ])
-        
+
         if result[6] != 0:
             raise LowlevelErrorException(result[6], "The spi command returned an error:\n    %s" % lowlevelErrorToString(result[6]))
 
@@ -1371,12 +1371,12 @@ class UE9(Device):
 
     def asynchConfig(self, Update = True, UARTEnable = True, DesiredBaud  = 9600):
         """
-        Name: UE9.asynchConfig(Update = True, UARTEnable = True, 
+        Name: UE9.asynchConfig(Update = True, UARTEnable = True,
                               DesiredBaud = 9600)
         Args: See section 5.3.17 of the User's Guide.
 
-        Desc: Configures the U3 UART for asynchronous communication. 
-        
+        Desc: Configures the U3 UART for asynchronous communication.
+
         returns a dictionary:
         {
             'Update' : True means new parameters were written
@@ -1384,9 +1384,9 @@ class UE9(Device):
             'BaudFactor' : The baud factor being used
         }
         """
-        
+
         command = [ 0 ] * 10
-            
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
@@ -1394,21 +1394,21 @@ class UE9(Device):
         #command[4] = Checksum16 (LSB)
         #command[5] = Checksum16 (MSB)
         #command[6] = 0x00
-        
+
         if Update:
             command[7] |= ( 1 << 7 )
         if UARTEnable:
             command[7] |= ( 1 << 6 )
-        
+
         BaudFactor = (2**16) - 48000000/(2 * DesiredBaud)
         t = pack("<H", BaudFactor)
         command[8] = ord(t[0])
         command[9] = ord(t[1])
-        
+
         result = self._writeRead(command, 10, [0xF8, 0x02, 0x14])
-        
+
         returnDict = {}
-        
+
         if (result[7] >> 7) & 1:
             returnDict['Update'] = True
         else:
@@ -1417,7 +1417,7 @@ class UE9(Device):
             returnDict['UARTEnable'] = True
         else:
             returnDict['UARTEnable'] = False
-            
+
         returnDict['BaudFactor'] = unpack("<H", pack("BB", *result[8:]))[0]
 
         return returnDict
@@ -1428,7 +1428,7 @@ class UE9(Device):
         Args: AsynchBytes, must be a list of bytes to transfer.
         Desc: Sends bytes to the U3 UART which will be sent asynchronously on
               the transmit line. See section 5.3.18 of the user's guide.
-        
+
         returns a dictionary:
         {
             'NumAsynchBytesSent' : Number of Asynch Bytes Sent
@@ -1438,17 +1438,17 @@ class UE9(Device):
         """
         if not isinstance(AsynchBytes, list):
             raise LabJackException("AsynchBytes must be a list")
-        
+
         numBytes = len(AsynchBytes)
-        
+
         oddPacket = False
         if numBytes%2 != 0:
             AsynchBytes.append(0)
             numBytes = numBytes+1
             oddPacket = True
-        
+
         command = [ 0 ] * ( 8 + numBytes)
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 1 + ( numBytes/2 )
@@ -1459,11 +1459,11 @@ class UE9(Device):
         command[7] = numBytes
         if oddPacket:
             command[7] = numBytes - 1
-        
+
         command[8:] = AsynchBytes
-        
+
         result = self._writeRead(command, 10, [0xF8, 0x02, 0x15])
-        
+
         return { 'NumAsynchBytesSent' : result[7], 'NumAsynchBytesInRXBuffer' : result[8] }
 
     def asynchRX(self, Flush = False):
@@ -1482,7 +1482,7 @@ class UE9(Device):
         }
         """
         command = [ 0 ] * 8
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x01
@@ -1492,10 +1492,10 @@ class UE9(Device):
         #command[6] = 0x00
         if Flush:
             command[7] = 1
-        
-        
+
+
         result = self._writeRead(command, 40, [0xF8, 0x11, 0x16])
-        
+
         return { 'AsynchBytes' : result[8:], 'NumAsynchBytesInRXBuffer' : result[7] }
 
     def i2c(self, Address, I2CBytes, EnableClockStretching = False, NoStopWhenRestarting = False, ResetAtStart = False, SpeedAdjust = 0, SDAPinNum = 1, SCLPinNum = 0, NumI2CBytesToReceive = 0, AddressByte = None):
@@ -1578,7 +1578,7 @@ class UE9(Device):
               Section 5.3.21 of the User's Guide.
         """
         command = [ 0 ] * 10
-        
+
         #command[0] = Checksum8
         command[1] = 0xF8
         command[2] = 0x02
@@ -1589,16 +1589,16 @@ class UE9(Device):
         command[7] = ClockPinNum
         #command[8] = Reserved
         command[9] = SHTOptions
-        
+
         result = self._writeRead(command, 16, [ 0xF8, 0x05, 0x39])
-        
+
         val = (result[11]*256) + result[10]
         temp = -39.60 + 0.01*val
-        
+
         val = (result[14]*256) + result[13]
         humid = -4 + 0.0405*val + -.0000028*(val*val)
         humid = (temp - 25)*(0.01 + 0.00008*val) + humid
-         
+
         return { 'StatusReg' : result[8], 'StatusCRC' : result[9], 'Temperature' : temp, 'TemperatureCRC' : result[12], 'Humidity' : humid, 'HumidityCRC' : result[15] }
 
     def getAIN(self, channel, BipGain = 0x00, Resolution = 12, SettlingTime = 0):
@@ -1629,7 +1629,7 @@ class UE9(Device):
                           devices to ensure proper conversion.
         Desc: Converts the binary value returned from Feedback and SingleIO
               to a calibrated, analog voltage.
-        
+
         >>> print(d.singleIO(4, 1, BipGain = 0x01, Resolution = 12))
         {'AIN1': 65520.0}
         >>> print(d.binaryToCalibratedAnalogVoltage(65520.0, 0x01, 12))
@@ -1669,9 +1669,9 @@ class UE9(Device):
         else:
             slope = DEFAULT_CAL_CONSTANTS['DACSlopes'][str(dacNumber)]
             offset = DEFAULT_CAL_CONSTANTS['DACOffsets'][str(dacNumber)]
-        
+
         bits = (volts * slope) + offset
-        
+
         return int(max(min(bits, 0xFFF), 0))
 
     def getCalibrationData(self):
@@ -1680,7 +1680,7 @@ class UE9(Device):
         Args: None
         Desc: Reads the calibration constants off the UE9, and stores them
               for use with binaryToCalibratedAnalogVoltage.
-        
+
         Note: Please note that this function calls controlConfig to check
               if the device is a UE9 or not. It also makes calls to
               readMem, so please don't call this while streaming.
@@ -1736,13 +1736,13 @@ class UE9(Device):
 
     def readDefaultsConfig(self):
         """
-        Name: UE9.readDefaultsConfig( ) 
+        Name: UE9.readDefaultsConfig( )
         Args: None
         Desc: Reads the power-up defaults stored in flash.
         """
         results = dict()
         defaults = self.readDefaults(0)
-        
+
         results['FIODirection'] = defaults[4]
         results['FIOState'] = defaults[5]
         results['EIODirection'] = defaults[6]
@@ -1751,98 +1751,98 @@ class UE9(Device):
         results['CIOState'] = defaults[9]
         results['MIODirection'] = defaults[10]
         results['MIOState'] = defaults[11]
-        
+
         results['ConfigWriteMask'] = defaults[16]
         results['NumOfTimersEnable'] = defaults[17]
         results['CounterMask'] = defaults[18]
         results['PinOffset'] = defaults[19]
-        
+
         defaults = self.readDefaults(1)
         results['ClockSource'] = defaults[0]
         results['Divisor'] = defaults[1]
-        
+
         results['TMR0Mode'] = defaults[16]
         results['TMR0ValueL'] = defaults[17]
         results['TMR0ValueH'] = defaults[18]
-        
+
         results['TMR1Mode'] = defaults[20]
         results['TMR1ValueL'] = defaults[21]
         results['TMR1ValueH'] = defaults[22]
-        
+
         results['TMR2Mode'] = defaults[24]
         results['TMR2ValueL'] = defaults[25]
         results['TMR2ValueH'] = defaults[26]
-        
+
         results['TMR3Mode'] = defaults[28]
         results['TMR3ValueL'] = defaults[29]
         results['TMR3ValueH'] = defaults[30]
-        
+
         defaults = self.readDefaults(2)
-        
+
         results['TMR4Mode'] = defaults[0]
         results['TMR4ValueL'] = defaults[1]
         results['TMR4ValueH'] = defaults[2]
-        
+
         results['TMR5Mode'] = defaults[4]
         results['TMR5ValueL'] = defaults[5]
         results['TMR5ValueH'] = defaults[6]
-        
+
         results['DAC0'] = unpack( "<H", pack("BB", *defaults[16:18]) )[0]
-        
+
         results['DAC1'] = unpack( "<H", pack("BB", *defaults[20:22]) )[0]
-        
+
         defaults = self.readDefaults(3)
-        
+
         for i in range(14):
             results["AIN%sRes" % i] = defaults[i]
             results["AIN%sBPGain" % i] = defaults[i+16]
-        
+
         defaults = self.readDefaults(4)
         for i in range(14):
             results["AIN%sSettling" % i] = defaults[i]
-        
+
         return results
 
     def exportConfig(self):
         """
-        Name: UE9.exportConfig( ) 
+        Name: UE9.exportConfig( )
         Args: None
         Desc: Takes the current configuration and puts it into a ConfigParser
               object. Useful for saving the setup of your UE9.
         """
         # Make a new configuration file
         parser = ConfigParser.SafeConfigParser()
-        
+
         # Change optionxform so that options preserve their case.
         parser.optionxform = str
-        
+
         # Local Id and name
         self.commConfig()
         self.controlConfig()
-        
+
         section = "Identifiers"
         parser.add_section(section)
         parser.set(section, "Local ID", str(self.localId))
         parser.set(section, "Name", str(self.getName()))
         parser.set(section, "Device Type", str(self.devType))
         parser.set(section, "MAC Address", str(self.macAddress))
-        
+
         # Comm Config settings
         section = "Communication"
         parser.add_section(section)
-        
+
         parser.set(section, "DHCPEnabled", str(self.DHCPEnabled))
         parser.set(section, "IP Address", str(self.ipAddress))
         parser.set(section, "Subnet", str(self.subnet))
         parser.set(section, "Gateway", str(self.gateway))
         parser.set(section, "PortA", str(self.portA))
         parser.set(section, "PortB", str(self.portB))
-        
-        
+
+
         # FIO Direction / State
         section = "FIOs"
         parser.add_section(section)
-        
+
         parser.set(section, "FIO Directions", str( self.readRegister(6750) ))
         parser.set(section, "FIO States", str( self.readRegister(6700) ))
         parser.set(section, "EIO Directions", str( self.readRegister(6751) ))
@@ -1851,71 +1851,71 @@ class UE9(Device):
         parser.set(section, "CIO States", str( self.readRegister(6702) ))
         #parser.set(section, "MIOs Directions", str( self.readRegister(50591) ))
         #parser.set(section, "MIOs States", str( self.readRegister(50591) ))
-            
+
         # DACs
         section = "DACs"
         parser.add_section(section)
-        
+
         dac0 = self.readRegister(5000)
         dac0 = max(dac0, 0)
         dac0 = min(dac0, 5)
         parser.set(section, "DAC0", "%0.2f" % dac0)
-        
+
         dac1 = self.readRegister(5002)
         dac1 = max(dac1, 0)
         dac1 = min(dac1, 5)
         parser.set(section, "DAC1", "%0.2f" % dac1)
-        
+
         # Timer Clock Configuration
         section = "Timer Clock Speed Configuration"
         parser.add_section(section)
-        
+
         parser.set(section, "TimerClockBase", str(self.readRegister(7000)))
         parser.set(section, "TimerClockDivisor", str(self.readRegister(7002)))
-        
+
         # Timers / Counters
         section = "Timers And Counters"
         parser.add_section(section)
-        
+
         nte = self.readRegister(50501)
         cm = self.readRegister(50502)
         ec0 = bool( cm & 1 )
         ec1 = bool( (cm >> 1) & 1 )
-        
+
         parser.set(section, "NumberTimersEnabled", str(nte) )
         parser.set(section, "Counter0Enabled", str(ec0) )
         parser.set(section, "Counter1Enabled", str(ec1) )
-        
+
         for i in range(nte):
             mode, value = self.readRegister(7100 + (i*2), numReg = 2, format = ">HH")
             parser.set(section, "Timer%s Mode" % i, str(mode))
             parser.set(section, "Timer%s Value" % i, str(value))
-            
-        
-        
+
+
+
         return parser
 
     def loadConfig(self, configParserObj):
         """
-        Name: UE9.loadConfig( configParserObj ) 
+        Name: UE9.loadConfig( configParserObj )
         Args: configParserObj, A Config Parser object to load in
         Desc: Takes a configuration and updates the UE9 to match it.
         """
         parser = configParserObj
-        
+
         # Set Identifiers:
         section = "Identifiers"
         if parser.has_section(section):
             if parser.has_option(section, "device type"):
                 if parser.getint(section, "device type") != self.devType:
                     raise Exception("Not a UE9 Config file.")
-            
+
             if parser.has_option(section, "local id"):
                 self.commConfig( LocalID = parser.getint(section, "local id"))
-                
+
             if parser.has_option(section, "name"):
                 self.setName( parser.get(section, "name") )
-        
+
         # Comm Config settings
         section = "Communication"
         if parser.has_section(section):
@@ -1925,115 +1925,115 @@ class UE9(Device):
             gateway = None
             portA = None
             portB = None
-            
+
             if parser.has_option(section, "DHCPEnabled"):
                 DHCPEnabled = parser.getboolean(section, "DHCPEnabled")
-                
+
             if parser.has_option(section, "ipAddress"):
                 ipAddress = parser.get(section, "ipAddress")
-                
+
             if parser.has_option(section, "subnet"):
                 subnet = parser.get(section, "subnet")
-            
+
             if parser.has_option(section, "gateway"):
                 gateway = parser.get(section, "gateway")
-            
+
             if parser.has_option(section, "portA"):
                 portA = parser.getint(section, "portA")
-                
+
             if parser.has_option(section, "portB"):
                 portB = parser.getint(section, "portB")
-                
+
             self.commConfig( DHCPEnabled = DHCPEnabled, IPAddress = ipAddress, Subnet = subnet, Gateway = gateway, PortA = portA, PortB = portB )
-        
-        
+
+
         # Set FIOs:
         section = "FIOs"
         if parser.has_section(section):
             fiodirs = 0
             eiodirs = 0
             ciodirs = 0
-            
+
             fiostates = 0
             eiostates = 0
             ciostates = 0
-            
+
             if parser.has_option(section, "fios directions"):
                 fiodirs = parser.getint(section, "fios directions")
             if parser.has_option(section, "eios directions"):
                 eiodirs = parser.getint(section, "eios directions")
             if parser.has_option(section, "cios directions"):
                 ciodirs = parser.getint(section, "cios directions")
-            
+
             if parser.has_option(section, "fios states"):
                 fiostates = parser.getint(section, "fios states")
             if parser.has_option(section, "eios states"):
                 eiostates = parser.getint(section, "eios states")
             if parser.has_option(section, "cios states"):
                 ciostates = parser.getint(section, "cios states")
-            
+
             bitmask = 0xff00
-            
+
             # FIO State/Dir
             self.writeRegister(6700, bitmask + fiostates )
             self.writeRegister(6750, bitmask + fiodirs )
-            
+
             # EIO State/Dir
             self.writeRegister(6701, bitmask + eiostates )
             self.writeRegister(6751, bitmask + eiodirs )
-            
+
             # CIO State/Dir
             self.writeRegister(6702, bitmask + ciostates )
             self.writeRegister(6752, bitmask + ciodirs )
-            
-                
+
+
         # Set DACs:
         section = "DACs"
         if parser.has_section(section):
             if parser.has_option(section, "dac0"):
                 self.writeRegister(5000, parser.getfloat(section, "dac0"))
-            
+
             if parser.has_option(section, "dac1"):
                 self.writeRegister(5002, parser.getfloat(section, "dac1"))
-                
+
         # Set Timer Clock Configuration
         section = "Timer Clock Speed Configuration"
         if parser.has_section(section):
             if parser.has_option(section, "timerclockbase"):
                 self.writeRegister(7000, parser.getint(section, "timerclockbase"))
-            
+
             if parser.has_option(section, "timerclockdivisor"):
                 self.writeRegister(7002, parser.getint(section, "timerclockbase"))
-        
+
         # Set Timers / Counters
         section = "Timers And Counters"
         if parser.has_section(section):
             nte = 0
-            
+
             if parser.has_option(section, "NumberTimersEnabled"):
                 nte = parser.getint(section, "NumberTimersEnabled")
                 self.writeRegister(50501, nte)
-            
+
             if parser.has_option(section, "Counter0Enabled"):
                 cm = (self.readRegister(50502) & 2) # 0b10
                 c0e = parser.getboolean(section, "Counter0Enabled")
                 self.writeRegister(50502, cm + int(c0e))
-            
+
             if parser.has_option(section, "Counter1Enabled"):
                 cm = (self.readRegister(50502) & 1) # 0b01
                 c1e = parser.getboolean(section, "Counter1Enabled")
                 self.writeRegister(50502, (int(c1e) << 1) + 1)
-            
-            
-            
+
+
+
             mode = None
             value = None
-            
+
             for i in range(nte):
                 if parser.has_option(section, "timer%s mode"):
                     mode = parser.getint(section, "timer%s mode")
-                    
+
                     if parser.has_option(section, "timer%s value"):
                         value = parser.getint(section, "timer%s mode")
-                    
+
                     self.writeRegister(7100 + (i*2), [mode, value])

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -275,7 +275,7 @@ class UE9(Device):
         listen = True
         while listen:
             #We will wait 2 seconds for a response from a Ue9
-            rs,ws,es = select.select(inputs, [], [], 1)
+            rs, _, _ = select.select(inputs, [], [], 1)
             listen = False
             for r in rs:
                 if r is s:
@@ -559,7 +559,7 @@ class UE9(Device):
 
         """
 'AIN0' : b2c(unpackShort(result[12:14])), 'AIN1' : unpackShort(result[14:16]), 'AIN2' : unpackShort(result[16:18]), 'AIN3' : unpackShort(result[18:20]), 'AIN4' : unpackShort(result[20:22]), 'AIN5' : unpackShort(result[22:24]), 'AIN6' : unpackShort(result[24:26]), 'AIN7' : unpackShort(result[26:28]), 'AIN8' : unpackShort(result[28:30]), 'AIN9' : unpackShort(result[30:32]), 'AIN10' : unpackShort(result[32:34]), 'AIN11' : unpackShort(result[34:36]), 'AIN12' : unpackShort(result[36:38]), 'AIN13' : unpackShort(result[38:40]), 'AIN14' : unpackShort(result[40:42]), 'AIN15' : unpackShort(result[42:44]),
-        """
+        """ # pylint:disable=pointless-string-statement
 
         b2c = self.binaryToCalibratedAnalogVoltage
         g = 0
@@ -886,7 +886,7 @@ class UE9(Device):
         Note: Use before and/or after streaming.  Timeout delay can occur occur.
         """
         try:
-            for i in range(10):
+            for _ in range(10):
                 res = self.read(192, stream = True)
                 if len(res) == 192:
                     if all([streamByteToInt(b) == 0 for b in res]):

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -711,62 +711,86 @@ class UE9(Device):
         # Create EnableMask
         if UpdateConfig:
             command[7] = 128 | NumTimersEnabled
-            if Counter0Enabled: command[7] = command[7] | 8
-            if Counter1Enabled: command[7] = command[7] | 16
-        else: UpdateConfig = 0
+            if Counter0Enabled:
+                command[7] = command[7] | 8
+            if Counter1Enabled:
+                command[7] = command[7] | 16
+        else:
+            UpdateConfig = 0
 
         # Configure clock base
         command[8] = TimerClockBase
 
         # Configure UpdateReset
-        if ResetTimer0: command[9] = 1
-        if ResetTimer1: command[9] = command[9] | 2
-        if ResetTimer2: command[9] = command[9] | 4
-        if ResetTimer3: command[9] = command[9] | 8
-        if ResetTimer4: command[9] = command[9] | 16
-        if ResetTimer5: command[9] = command[9] | 32
-        if ResetCounter0: command[9] = command[9] | 64
-        if ResetCounter1: command[9] = command[9] | 128
+        if ResetTimer0:
+            command[9] = 1
+        if ResetTimer1:
+            command[9] = command[9] | 2
+        if ResetTimer2:
+            command[9] = command[9] | 4
+        if ResetTimer3:
+            command[9] = command[9] | 8
+        if ResetTimer4:
+            command[9] = command[9] | 16
+        if ResetTimer5:
+            command[9] = command[9] | 32
+        if ResetCounter0:
+            command[9] = command[9] | 64
+        if ResetCounter1:
+            command[9] = command[9] | 128
 
         # Configure timers and counters if we are updating the configuration
         if UpdateConfig:
             if NumTimersEnabled >= 1:
-                if Timer0Mode is None: raise LabJackException("Need to specify a mode for Timer0")
-                if Timer0Value is None: raise LabJackException("Need to specify a value for Timer0")
+                if Timer0Mode is None:
+                    raise LabJackException("Need to specify a mode for Timer0")
+                if Timer0Value is None:
+                    raise LabJackException("Need to specify a value for Timer0")
                 command[10] = Timer0Mode
                 command[11] = Timer0Value & 0xff
                 command[12] = (Timer0Value >> 8) & 0xff
             if NumTimersEnabled >= 2:
-                if Timer1Mode is None: raise LabJackException("Need to specify a mode for Timer1")
-                if Timer1Value is None: raise LabJackException("Need to specify a value for Timer1")
+                if Timer1Mode is None:
+                    raise LabJackException("Need to specify a mode for Timer1")
+                if Timer1Value is None:
+                    raise LabJackException("Need to specify a value for Timer1")
                 command[13] = Timer1Mode
                 command[14] = Timer1Value & 0xff
                 command[15] = (Timer1Value >> 8) & 0xff
             if NumTimersEnabled >= 3:
-                if Timer2Mode is None: raise LabJackException("Need to specify a mode for Timer2")
-                if Timer2Value is None: raise LabJackException("Need to specify a value for Timer2")
+                if Timer2Mode is None:
+                    raise LabJackException("Need to specify a mode for Timer2")
+                if Timer2Value is None:
+                    raise LabJackException("Need to specify a value for Timer2")
                 command[16] = Timer2Mode
                 command[17] = Timer2Value & 0xff
                 command[18] = (Timer2Value >> 8) & 0xff
             if NumTimersEnabled >= 4:
-                if Timer3Mode is None: raise LabJackException("Need to specify a mode for Timer3")
-                if Timer3Value is None: raise LabJackException("Need to specify a value for Timer3")
+                if Timer3Mode is None:
+                    raise LabJackException("Need to specify a mode for Timer3")
+                if Timer3Value is None:
+                    raise LabJackException("Need to specify a value for Timer3")
                 command[19] = Timer3Mode
                 command[20] = Timer3Value & 0xff
                 command[21] = (Timer3Value >> 8) & 0xff
             if NumTimersEnabled >= 5:
-                if Timer4Mode is None: raise LabJackException("Need to specify a mode for Timer4")
-                if Timer4Value is None: raise LabJackException("Need to specify a value for Timer4")
+                if Timer4Mode is None:
+                    raise LabJackException("Need to specify a mode for Timer4")
+                if Timer4Value is None:
+                    raise LabJackException("Need to specify a value for Timer4")
                 command[22] = Timer4Mode
                 command[23] = Timer4Value & 0xff
                 command[24] = (Timer4Value >> 8) & 0xff
             if NumTimersEnabled == 6:
-                if Timer5Mode is None: raise LabJackException("Need to specify a mode for Timer5")
-                if Timer5Value is None: raise LabJackException("Need to specify a value for Timer5")
+                if Timer5Mode is None:
+                    raise LabJackException("Need to specify a mode for Timer5")
+                if Timer5Value is None:
+                    raise LabJackException("Need to specify a value for Timer5")
                 command[25] = Timer5Mode
                 command[26] = Timer5Value & 0xff
                 command[27] = (Timer5Value >> 8) & 0xff
-            if NumTimersEnabled > 7: raise LabJackException("Only a maximum of 5 timers can be enabled")
+            if NumTimersEnabled > 7:
+                raise LabJackException("Only a maximum of 5 timers can be enabled")
             command[28] = 0  # command[28] = Counter0Mode
             command[29] = 0  # command[29] = Counter1Mode
 

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -52,16 +52,20 @@ def openAllUE9():
 
     return returnDict
 
+
 def parseIpAddress(bytes):
     return "%s.%s.%s.%s" % (bytes[3], bytes[2], bytes[1], bytes[0])
 
+
 def unpackInt(bytes):
     return unpack("<I", pack("BBBB", *bytes))[0]
+
 
 def unpackShort(bytes):
     return unpack("<H", pack("BB", *bytes))[0]
 
 DEFAULT_CAL_CONSTANTS = {"AINSlopes": {'0': 0.000077503, '1': 0.000038736, '2': 0.000019353, '3': 0.0000096764, '8': 0.00015629}, "AINOffsets": {'0': -0.012000, '1': -0.012000, '2': -0.012000, '3': -0.012000, '8': -5.1760}, "TempSlope": 0.012968, "DACSlopes": {'0': 842.59, '1': 842.59}, "DACOffsets": {'0': 0.0, '1': 0.0}}
+
 
 class UE9(Device):
     """

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -1081,7 +1081,7 @@ class UE9(Device):
         Note: You must call streamConfig() before calling this function.
         """
         self.flushBuffer()
-        if self.streamStarted == False and clearData == True:
+        if not self.streamStarted and clearData is True:
             self.streamClearData()
         Device.streamStart(self)
 
@@ -1124,7 +1124,7 @@ class UE9(Device):
             zeroVal = 0
 
         while True:
-            if self.ethernet and newTimeLoop == True:
+            if self.ethernet and newTimeLoop is True:
                 newTimeLoop = False
                 startTime = datetime.datetime.now()
 
@@ -1150,7 +1150,7 @@ class UE9(Device):
                         print(e)
                 i += 1
 
-            if len(result) == 0 and self.ethernet == False:
+            if len(result) == 0 and not self.ethernet:
                 # No data over USB
                 yield None
                 continue
@@ -1206,7 +1206,7 @@ class UE9(Device):
         """
         Device.streamStop(self)
         self.flushBuffer()
-        if self.streamStarted == False and clearData == True:
+        if not self.streamStarted and clearData is True:
             self.streamClearData()
 
     def processStreamData(self, result, numBytes=None):
@@ -1229,7 +1229,7 @@ class UE9(Device):
         numChannels = len(self.streamChannelNumbers)
         j = self.streamPacketOffset
         for packet in self.breakupPackets(result, numBytes):
-            if self.ethernet == False:
+            if not self.ethernet:
                 packet = packet[:-2]  # remove the extra bytes
             for sample in self.samplesFromPacket(packet):
                 if j >= numChannels:

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -559,7 +559,7 @@ class UE9(Device):
 
         """
 'AIN0' : b2c(unpackShort(result[12:14])), 'AIN1' : unpackShort(result[14:16]), 'AIN2' : unpackShort(result[16:18]), 'AIN3' : unpackShort(result[18:20]), 'AIN4' : unpackShort(result[20:22]), 'AIN5' : unpackShort(result[22:24]), 'AIN6' : unpackShort(result[24:26]), 'AIN7' : unpackShort(result[26:28]), 'AIN8' : unpackShort(result[28:30]), 'AIN9' : unpackShort(result[30:32]), 'AIN10' : unpackShort(result[32:34]), 'AIN11' : unpackShort(result[34:36]), 'AIN12' : unpackShort(result[36:38]), 'AIN13' : unpackShort(result[38:40]), 'AIN14' : unpackShort(result[40:42]), 'AIN15' : unpackShort(result[42:44]),
-        """ # pylint:disable=pointless-string-statement
+        """
 
         b2c = self.binaryToCalibratedAnalogVoltage
         g = 0

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -22,20 +22,11 @@ except ImportError:  # Python 3
 
 from struct import pack, unpack
 
-from LabJackPython import (
-    Device,
-    deviceCount,
-    LabJackException,
-    LJ_tcSYS,
-    LowlevelErrorException,
-    lowlevelErrorToString,
-    setChecksum8,
-    streamByteToInt,
-    toDouble,
-    UE9TCPHandle,
-    verifyChecksum,
-    _use_py2,
-    )
+from LabJackPython import (Device, deviceCount, LabJackException,
+                           LJ_tcSYS, LowlevelErrorException,
+                           lowlevelErrorToString, setChecksum8,
+                           streamByteToInt, toDouble, UE9TCPHandle,
+                           verifyChecksum, _use_py2)
 
 
 def openAllUE9():
@@ -579,6 +570,7 @@ class UE9(Device):
         return returnDict
 
     digitalPorts = ['FIO', 'EIO', 'CIO', 'MIO']
+
     def singleIO(self, IOType, Channel, Dir=None, BipGain=None, State=None, Resolution=None, DAC=0, SettlingTime=0):
         """
         Name: UE9.singleIO(IOType, Channel, Dir = None, BipGain = None, State = None, Resolution = None, DAC = 0, SettlingTime = 0)
@@ -1521,7 +1513,6 @@ class UE9(Device):
         if Flush:
             command[7] = 1
 
-
         result = self._writeRead(command, 40, [0xF8, 0x11, 0x16])
 
         return {'AsynchBytes': result[8:], 'NumAsynchBytesInRXBuffer': result[7]}
@@ -1866,7 +1857,6 @@ class UE9(Device):
         parser.set(section, "PortA", str(self.portA))
         parser.set(section, "PortB", str(self.portB))
 
-
         # FIO Direction / State
         section = "FIOs"
         parser.add_section(section)
@@ -1918,8 +1908,6 @@ class UE9(Device):
             mode, value = self.readRegister(7100 + (i * 2), numReg=2, format=">HH")
             parser.set(section, "Timer%s Mode" % i, str(mode))
             parser.set(section, "Timer%s Value" % i, str(value))
-
-
 
         return parser
 
@@ -1974,7 +1962,6 @@ class UE9(Device):
 
             self.commConfig(DHCPEnabled=DHCPEnabled, IPAddress=ipAddress, Subnet=subnet, Gateway=gateway, PortA=portA, PortB=portB)
 
-
         # Set FIOs:
         section = "FIOs"
         if parser.has_section(section):
@@ -2014,7 +2001,6 @@ class UE9(Device):
             self.writeRegister(6702, bitmask + ciostates)
             self.writeRegister(6752, bitmask + ciodirs)
 
-
         # Set DACs:
         section = "DACs"
         if parser.has_section(section):
@@ -2051,8 +2037,6 @@ class UE9(Device):
                 cm = (self.readRegister(50502) & 1)  # 0b01
                 c1e = parser.getboolean(section, "Counter1Enabled")
                 self.writeRegister(50502, (int(c1e) << 1) + 1)
-
-
 
             mode = None
             value = None


### PR DESCRIPTION
Note that the whitespace patch produces no diff output when run with `git diff -w'.