### PR TITLE
Fix TypeError when handle is None on Python 3

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -1239,12 +1239,12 @@ def _openLabJackUsingExodriver(deviceType, firstFound, pAddress, devNumber):
 
     if devNumber is not None:
         handle = openDev(devNumber, 0, devType)
-        if handle <= 0:
+        if handle is None or handle <= 0:
             raise NullHandleException()
         return handle
     elif firstFound:
         handle = openDev(1, 0, devType)
-        if handle <= 0:
+        if handle is None or handle <= 0:
             raise NullHandleException()
         return handle
     else:      
@@ -1254,7 +1254,7 @@ def _openLabJackUsingExodriver(deviceType, firstFound, pAddress, devNumber):
             handle = openDev(i + 1, 0, devType)
             
             try:
-                if handle <= 0:
+                if handle is None or handle <= 0:
                     raise NullHandleException()
                 device = _makeDeviceFromHandle(handle, deviceType)
             except:


### PR DESCRIPTION
Fixes #103.  Adds an explicit check for `None` on the handle returned by `openDev()`.   

Python 3 changed the behavior of comparing `None` to `int` as shown below.  

```
$ python2
>>> None <= 0
True

$ python3
>>> None <= 0
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: '<=' not supported between instances of 'NoneType' and 'int'
```

