### PR TITLE
handled a bug with packing more than was read

### DIFF
--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -349,7 +349,7 @@ class Device(object):
             if readBytes == 0:
                 return ''
             # return the byte string in stream mode
-            return pack('b' * readBytes, *newA)
+            return pack('b' * readBytes, *newA[0:readBytes])
         else:
             readBytes = staticLib.LJUSB_Read(self.handle, ctypes.byref(newA), numBytes)
             # return a list of integers in command/response mode


### PR DESCRIPTION
When readBytes is less than len(*newA) pack fails with
" struct.error: pack expected 192 items for packing (got 256)" 

This pull requests solves that
