### PR TITLE
Fix for changing arguments with serial communication methods.

### DIFF
--- a/src/u3.py
+++ b/src/u3.py
@@ -1270,7 +1270,6 @@ class U3(Device):
 
         oddPacket = False
         if numSPIBytes%2 != 0:
-            SPIBytes.append(0)
             numSPIBytes = numSPIBytes + 1
             oddPacket = True
 
@@ -1305,7 +1304,7 @@ class U3(Device):
         if oddPacket:
             command[13] = numSPIBytes - 1
 
-        command[14:] = SPIBytes
+        command[14:] = SPIBytes + [0]*oddPacket
 
         result = self._writeRead(command, 8+numSPIBytes, [0xF8, 1+(numSPIBytes//2), 0x3A])
 
@@ -1413,7 +1412,6 @@ class U3(Device):
 
         oddPacket = False
         if numBytes%2 != 0:
-            AsynchBytes.append(0)
             numBytes = numBytes + 1
             oddPacket = True
 
@@ -1430,7 +1428,7 @@ class U3(Device):
         if oddPacket:
             command[7] = numBytes - 1
 
-        command[8:] = AsynchBytes
+        command[8:] = AsynchBytes + [0]*oddPacket
 
         result = self._writeRead(command, 10, [0xF8, 0x02, 0x15])
 
@@ -1504,7 +1502,6 @@ class U3(Device):
 
         oddPacket = False
         if numBytes%2 != 0:
-            I2CBytes.append(0)
             numBytes = numBytes + 1
             oddPacket = True
 
@@ -1534,7 +1531,7 @@ class U3(Device):
         if oddPacket:
             command[12] = numBytes - 1
         command[13] = NumI2CBytesToReceive
-        command[14:] = I2CBytes
+        command[14:] = I2CBytes + [0]*oddPacket
 
         oddResponse = False
         if NumI2CBytesToReceive%2 != 0:


### PR DESCRIPTION
Don't mutate argument, even with odd lengths.

Test case:
```python
import u3

lj = u3.openAllU3().popitem()[1]

data = [1]

lj.i2c(0x10,data)

assert data == [1]
```
(I see that `u6.py` and `ue9.py` have the same problem, but I don't have hardware to test those.)