### PR TITLE
Added support for .debug as a logging.Logger object

### DIFF
--- a/src/u12.py
+++ b/src/u12.py
@@ -445,8 +445,7 @@ class U12(object):
         if _os_name == "nt":
             pass
         else:
-            if self.debug:
-                print("open called")
+            self._debugprint("open called")
             devType = ctypes.c_ulong(1)
             openDev = staticLib.LJUSB_OpenDevice
             openDev.restype = ctypes.c_void_p
@@ -537,8 +536,7 @@ class U12(object):
             if self.handle is None:
                 raise U12Exception("The U12's handle is None. Please open a U12 with open()")
 
-            if self.debug:
-                print("Writing: " + hexWithoutQuotes(writeBuffer))
+            self._debugprint("Writing: " + hexWithoutQuotes(writeBuffer))
             newA = (ctypes.c_byte*len(writeBuffer))(0)
             for i in range(len(writeBuffer)):
                 newA[i] = ctypes.c_byte(writeBuffer[i])
@@ -560,8 +558,7 @@ class U12(object):
             readBytes = staticLib.LJUSB_ReadTO(self.handle, ctypes.byref(newA), numBytes, timeout)
             # Return a list of integers in command-response mode
             result = [(newA[i] & 0xff) for i in range(readBytes)]
-            if self.debug:
-                print("Received: " + hexWithoutQuotes(result))
+            self._debugprint("Received: " + hexWithoutQuotes(result))
             return result
 
     # Low-level helpers

--- a/src/u3.py
+++ b/src/u3.py
@@ -73,7 +73,7 @@ class U3(Device):
         """
         Name: U3.__init__(debug = False, autoOpen = True, **openArgs)
 
-        Args: debug, enables debug output
+        Args: debug is False, True (for stdout) or a logging.Logger
               autoOpen, if true, the class will try to open a U3 using openArgs
               **openArgs, the arguments to pass to the open call. See U3.open()
         

--- a/src/u6.py
+++ b/src/u6.py
@@ -188,7 +188,7 @@ class U6(Device):
     def __init__(self, debug = False, autoOpen = True, **kargs):
         """
         Name: U6.__init__(self, debug = False, autoOpen = True, **kargs)
-        Args: debug, Do you want debug information?
+        Args: debug is False, True (for stdout) or a logging.Logger
               autoOpen, If true, then the constructor will call open for you
               **kargs, The arguments to be passed to open.
         Desc: Your basic constructor.
@@ -1186,8 +1186,7 @@ class U6(Device):
         >>> myU6.calInfo
         <ainDiffOffset: -2.46886488446,...>
         """
-        if self.debug is True:
-            print("Calibration data retrieval")
+        self._debugprint("Calibration data retrieval")
 
         self.calInfo.nominal = False
 

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -76,7 +76,7 @@ class UE9(Device):
     def __init__(self, debug = False, autoOpen = True, **kargs):
         """
         Name: UE9.__init__(self)
-        Args: debug, True for debug information
+        Args: debug is False, True (for stdout) or a logging.Logger
         Desc: Your basic constructor.
         
         >>> myUe9 = ue9.UE9()
@@ -1121,8 +1121,7 @@ class UE9(Device):
                 e = streamByteToInt(result[11+offset])
                 if e != 0:
                     errors += 1
-                    if self.debug:
-                        print(e)
+                    self._debugprint(e)
                 i+=1
 
             if len(result) == 0  and self.ethernet == False:


### PR DESCRIPTION
The support for debug on Devices currently all goes to stdout, which means it both interferes with normal stdout and doesn't interleave properly with the standard logging module.

I added support for debug to be an instance of logging.Logger, in which case it will output all messages to that logger object with DEBUG priority.  To maintain backwards compatibility, anything that is not a Logger continues to cause a call to print() if it evaluates truthy.