### PR TITLE
Fix minor bug in the example streamTest-threading.py

### DIFF
--- a/Examples/streamTest-threading.py
+++ b/Examples/streamTest-threading.py
@@ -135,7 +135,7 @@ class StreamDataReader(object):
             scanTotal = sampleTotal / 1  # sampleTotal / NumChannels
 
             print("%s requests with %s packets per request with %s samples per packet = %s samples total." %
-                  (self.dataCount, d.packetsPerRequest, d.streamSamplesPerPacket, sampleTotal))
+                  (self.dataCount, self.device.packetsPerRequest, self.device.streamSamplesPerPacket, sampleTotal))
 
             print("%s samples were lost due to errors." % self.missed)
             sampleTotal -= self.missed


### PR DESCRIPTION
The Class StreamDataReader uses the device object of the global scope. With this fix, the class StreamDataReader is independent of the particular device in this script and can be repurposed in other projects by users.