### PR TITLE
Added loadCalibration open parameter

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -342,3 +342,6 @@ Version History
     - Fixed some Python 3 related bugs in the getName method.
     - U3 and U6 optimizions for processStreamData and binary to analog
       conversion functions.
+- 2.2.0
+    - Added an optional loadCalibration parameter to the device open functions.
+      The open functions will now call getCalibrationData() by default.

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ CLASSIFIERS = [
     ]
 
 setup(name='LabJackPython',
-      version='2.1.0',
+      version='2.2.0',
       description='The LabJack Python modules for the LabJack U3, U6, UE9 and U12.',
       license='MIT X11',
       url='https://labjack.com/support/software/examples/ud/labjackpython',

--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -26,7 +26,7 @@ from struct import pack, unpack
 import Modbus
 
 
-LABJACKPYTHON_VERSION = "2.1.0"
+LABJACKPYTHON_VERSION = "2.2.0"
 __version__ = LABJACKPYTHON_VERSION
 
 SOCKET_TIMEOUT = 3

--- a/src/u3.py
+++ b/src/u3.py
@@ -103,7 +103,7 @@ class U3(Device):
             self.open(**kargs)
     __init__.section = 1
 
-    def open(self, firstFound = True, serial = None, localId = None, devNumber = None, handleOnly = False, LJSocket = None):
+    def open(self, firstFound = True, serial = None, localId = None, devNumber = None, handleOnly = False, LJSocket = None, loadCalibration = True):
         """
         Name: U3.open(firstFound = True, localId = None, devNumber = None,
                       handleOnly = False, LJSocket = None)
@@ -136,6 +136,8 @@ class U3(Device):
         >>> d.open(LJSocket = "localhost:6000")
         """
         Device.open(self, 3, firstFound = firstFound, serial = serial, localId = localId, devNumber = devNumber, handleOnly = handleOnly, LJSocket = LJSocket )
+        if loadCalibration:
+            self.getCalibrationData()
     open.section = 1
 
     def configU3(self, LocalID = None, TimerCounterConfig = None, FIOAnalog = None, FIODirection = None, FIOState = None, EIOAnalog = None, EIODirection = None, EIOState = None, CIODirection = None, CIOState = None, DAC1Enable = None, DAC0 = None, DAC1 = None, TimerClockConfig = None, TimerClockDivisor = None, CompatibilityOptions = None):

--- a/src/u6.py
+++ b/src/u6.py
@@ -216,7 +216,7 @@ class U6(Device):
         if autoOpen:
             self.open(**kargs)
 
-    def open(self, localId = None, firstFound = True, serial = None, devNumber = None, handleOnly = False, LJSocket = None):
+    def open(self, localId = None, firstFound = True, serial = None, devNumber = None, handleOnly = False, LJSocket = None, loadCalibration = True):
         """
         Name: U6.open(localId = None, firstFound = True, devNumber = None,
                       handleOnly = False, LJSocket = None)
@@ -232,6 +232,8 @@ class U6(Device):
         >>> myU6.open()
         """
         Device.open(self, 6, firstFound = firstFound, serial = serial, localId = localId, devNumber = devNumber, handleOnly = handleOnly, LJSocket = LJSocket )
+        if loadCalibration:
+            self.getCalibrationData()
 
     def configU6(self, LocalID = None):
         """

--- a/src/ue9.py
+++ b/src/ue9.py
@@ -91,7 +91,7 @@ class UE9(Device):
         if autoOpen:
             self.open(**kargs)
     
-    def open(self, firstFound = True, serial = None, ipAddress = None, localId = None, devNumber = None, ethernet=False, handleOnly = False, LJSocket = None):
+    def open(self, firstFound = True, serial = None, ipAddress = None, localId = None, devNumber = None, ethernet=False, handleOnly = False, LJSocket = None, loadCalibration = True):
         """
         Name: UE9.open(firstFound = True, ipAddress = None, localId = None, devNumber = None, ethernet=False)
         Args: firstFound, Open the first found UE9
@@ -109,6 +109,8 @@ class UE9(Device):
         """
         self.ethernet = ethernet
         Device.open(self, 9, Ethernet = ethernet, firstFound = firstFound, serial = serial, localId = localId, devNumber = devNumber, ipAddress = ipAddress, handleOnly = handleOnly, LJSocket = LJSocket)
+        if loadCalibration:
+            self.getCalibrationData()
 
     def commConfig(self, LocalID = None, IPAddress = None, Gateway = None, Subnet = None, PortA = None, PortB = None, DHCPEnabled = None):
         """


### PR DESCRIPTION
*Device open calls will now load calibration data by default
*Bumped the version to 2.2.0