### PR TITLE
Update u6.py, fix mistake in docstrings

### DIFF
--- a/src/u6.py
+++ b/src/u6.py
@@ -1457,7 +1457,6 @@ class U6(Device):
                   0 - 7   = FIO0 - FIO7
                   8 - 15  = EIO0 - EIO7
                   16 - 19 = CIO0 - CIO3
-                  16 - 18 = MIO0 - MIO2
               state, 1 = High, 0 = Low
         Desc: A convenience function to set the state of a digital I/O. Will
               also set the direction to output.
@@ -1476,7 +1475,6 @@ class U6(Device):
                   0 - 7   = FIO0 - FIO7
                   8 - 15  = EIO0 - EIO7
                   16 - 19 = CIO0 - CIO3
-                  16 - 18 = MIO0 - MIO2
         Desc: A convenience function to read the state of a digital I/O.  Will
               also set the direction to input.
         
@@ -1495,7 +1493,6 @@ class U6(Device):
                   0 - 7   = FIO0 - FIO7
                   8 - 15  = EIO0 - EIO7
                   16 - 19 = CIO0 - CIO3
-                  16 - 18 = MIO0 - MIO2
         Desc: A convenience function to read the state of a digital I/O.  Will
               not change the direction.
         

--- a/src/u6.py
+++ b/src/u6.py
@@ -1457,7 +1457,7 @@ class U6(Device):
                   0 - 7   = FIO0 - FIO7
                   8 - 15  = EIO0 - EIO7
                   16 - 19 = CIO0 - CIO3
-                  20 - 22 = MIO0 - MIO2
+                  16 - 18 = MIO0 - MIO2
               state, 1 = High, 0 = Low
         Desc: A convenience function to set the state of a digital I/O. Will
               also set the direction to output.
@@ -1476,7 +1476,7 @@ class U6(Device):
                   0 - 7   = FIO0 - FIO7
                   8 - 15  = EIO0 - EIO7
                   16 - 19 = CIO0 - CIO3
-                  20 - 22 = MIO0 - MIO2
+                  16 - 18 = MIO0 - MIO2
         Desc: A convenience function to read the state of a digital I/O.  Will
               also set the direction to input.
         
@@ -1495,7 +1495,7 @@ class U6(Device):
                   0 - 7   = FIO0 - FIO7
                   8 - 15  = EIO0 - EIO7
                   16 - 19 = CIO0 - CIO3
-                  20 - 22 = MIO0 - MIO2
+                  16 - 18 = MIO0 - MIO2
         Desc: A convenience function to read the state of a digital I/O.  Will
               not change the direction.
         


### PR DESCRIPTION
 Change the numbers in the docstrings of the methods
```python
self.setDOState(ioNum) 
self.getDIState(ioNum)
self.getDIOState(ioNum)
```
The docstrings state that arguments ioNum = 20, 21, 22 access the so called MIO digital I/O. The class BitStateRead will take the argument mod 20, s.t. the user intending to read MIO1 reads FIO1 etc. The hardware documentation states that MIO 0-2 are shared with CIO 0-2.