### PR TITLE
ctypes.c_byte to ctypes.c_ubyte fix

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -345,3 +345,5 @@ Version History
 - 2.2.0
     - Added an optional loadCalibration parameter to the device open functions.
       The open functions will now call getCalibrationData() by default.
+- 2.2.1
+    - Fixed issue where ctypes.c_byte was used instead of ctypes.c_ubyte.

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ CLASSIFIERS = [
     ]
 
 setup(name='LabJackPython',
-      version='2.2.0',
+      version='2.2.1',
       description='The LabJack Python modules for the LabJack U3, U6, UE9 and U12.',
       license='MIT X11',
       url='https://labjack.com/support/software/examples/ud/labjackpython',

--- a/src/LabJackPython.py
+++ b/src/LabJackPython.py
@@ -26,7 +26,7 @@ from struct import pack, unpack
 import Modbus
 
 
-LABJACKPYTHON_VERSION = "2.2.0"
+LABJACKPYTHON_VERSION = "2.2.1"
 __version__ = LABJACKPYTHON_VERSION
 
 SOCKET_TIMEOUT = 3
@@ -249,9 +249,9 @@ class Device(object):
         if modbus is True and self.modbusPrependZeros:
             writeBuffer = [ 0, 0 ] + writeBuffer
         
-        newA = (ctypes.c_byte*len(writeBuffer))(0) 
+        newA = (ctypes.c_ubyte*len(writeBuffer))(0) 
         for i in range(len(writeBuffer)):
-            newA[i] = ctypes.c_byte(writeBuffer[i])
+            newA[i] = ctypes.c_ubyte(writeBuffer[i])
         
         writeBytes = staticLib.LJUSB_Write(self.handle, ctypes.byref(newA), len(writeBuffer))
         
@@ -371,7 +371,7 @@ class Device(object):
         return list(rcvDataBuff)
 
     def _readFromExodriver(self, numBytes, stream, modbus):
-        newA = (ctypes.c_byte*numBytes)()
+        newA = (ctypes.c_ubyte*numBytes)()
         
         if stream:
             readBytes = staticLib.LJUSB_StreamTO(self.handle, ctypes.byref(newA), numBytes, 1500)
@@ -1824,9 +1824,9 @@ def eGetRaw(Handle, IOType, Channel, pValue, x1):
             #Initialize newA
             newA = None
             if type(x1[0]) == int:
-                newA = (ctypes.c_byte*len(x1))()
+                newA = (ctypes.c_ubyte*len(x1))()
                 for i in range(len(x1)):
-                    newA[i] = ctypes.c_byte(x1[i])
+                    newA[i] = ctypes.c_ubyte(x1[i])
             else:
                 x1Type = "float"
                 newA = (ctypes.c_double*len(x1))()

--- a/src/u12.py
+++ b/src/u12.py
@@ -552,9 +552,9 @@ class U12(object):
                 raise U12Exception("The U12's handle is None. Please open a U12 with open().")
 
             self._debugprint("Writing: " + hexWithoutQuotes(writeBuffer))
-            newA = (ctypes.c_byte*len(writeBuffer))(0)
+            newA = (ctypes.c_ubyte*len(writeBuffer))(0)
             for i in range(len(writeBuffer)):
-                newA[i] = ctypes.c_byte(writeBuffer[i])
+                newA[i] = ctypes.c_ubyte(writeBuffer[i])
 
             writeBytes = staticLib.LJUSB_Write(self.handle, ctypes.byref(newA), len(writeBuffer))
 
@@ -569,7 +569,7 @@ class U12(object):
         else:
             if self.handle is None:
                 raise U12Exception("The U12's handle is None. Please open a U12 with open().")
-            newA = (ctypes.c_byte*numBytes)()
+            newA = (ctypes.c_ubyte*numBytes)()
             readBytes = staticLib.LJUSB_ReadTO(self.handle, ctypes.byref(newA), numBytes, timeout)
             # Return a list of integers in command-response mode
             result = [(newA[i] & 0xff) for i in range(readBytes)]


### PR DESCRIPTION
ctypes.c_byte is specified to be equivalent to a signed char (-128 to 127) but we were passing unsigned char values (0-255) so we should be using ctypes.c_ubyte:
https://docs.python.org/3/library/ctypes.html#ctypes.c_byte

This issue causes some of our functions to throw exceptions when using IronPython.